### PR TITLE
Add staging user-data reset workflow

### DIFF
--- a/.github/DEPLOYMENT.md
+++ b/.github/DEPLOYMENT.md
@@ -140,8 +140,7 @@ Use the `Manage Staging Data` GitHub Actions workflow to manage staging test dat
 - Choose `list-users` to inspect available staging accounts.
 - Choose `seed-visualization-data` and provide an account email to seed historical visualization data.
 - Choose `clear-user-data` and provide an account email to wipe that user's app data before a fresh manual pass.
-- Type `SEED_STAGING` in the confirmation input before seeding historical visualization data.
-- Type `CLEAR_STAGING_USER_DATA` in the confirmation input before clearing a staging test account.
+- Type `MANAGE_STAGING_DATA` in the confirmation input before running any mutating staging-data action.
 - Configure `STAGING_MONGO_URI` as a secret on the `staging` GitHub environment.
 - `clear-user-data` preserves the `User` record but removes that user's categories, goals, lists, tasks, time entries, Google Calendar connection state, and sync metadata.
 - `clear-user-data` does not remove any events that were already written to Google Calendar. Clean up those external events separately if needed.

--- a/.github/DEPLOYMENT.md
+++ b/.github/DEPLOYMENT.md
@@ -135,9 +135,13 @@ Supported environment variables:
 
 Do not seed production. Staging can use controlled seed scripts or a dedicated test account after the staging database is isolated from production.
 
-Use the `Seed Staging Data` GitHub Actions workflow to manage staging visualization data:
+Use the `Manage Staging Data` GitHub Actions workflow to manage staging test data:
 
 - Choose `list-users` to inspect available staging accounts.
 - Choose `seed-visualization-data` and provide an account email to seed historical visualization data.
-- Type `SEED_STAGING` in the confirmation input before mutating staging data.
+- Choose `clear-user-data` and provide an account email to wipe that user's app data before a fresh manual pass.
+- Type `SEED_STAGING` in the confirmation input before seeding historical visualization data.
+- Type `CLEAR_STAGING_USER_DATA` in the confirmation input before clearing a staging test account.
 - Configure `STAGING_MONGO_URI` as a secret on the `staging` GitHub environment.
+- `clear-user-data` preserves the `User` record but removes that user's categories, goals, lists, tasks, time entries, Google Calendar connection state, and sync metadata.
+- `clear-user-data` does not remove any events that were already written to Google Calendar. Clean up those external events separately if needed.

--- a/.github/workflows/seed-staging-data.yml
+++ b/.github/workflows/seed-staging-data.yml
@@ -1,4 +1,4 @@
-name: Seed Staging Data
+name: Manage Staging Data
 
 on:
   workflow_dispatch:
@@ -10,13 +10,14 @@ on:
         options:
           - list-users
           - seed-visualization-data
+          - clear-user-data
         default: list-users
       email:
-        description: Account email to seed. Required for seed-visualization-data.
+        description: Account email to target. Required for mutating actions.
         required: false
         type: string
       confirmation:
-        description: Type SEED_STAGING to confirm staging data mutation.
+        description: Confirmation string for mutating actions.
         required: false
         type: string
 
@@ -25,7 +26,7 @@ permissions:
 
 jobs:
   seed-staging-data:
-    name: Seed Staging Data
+    name: Manage Staging Data
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: staging
@@ -71,6 +72,18 @@ jobs:
             fi
           fi
 
+          if [ "${SEED_ACTION}" = "clear-user-data" ]; then
+            if [ -z "${SEED_EMAIL}" ]; then
+              echo "email input is required when clearing staging user data." >&2
+              exit 1
+            fi
+
+            if [ "${SEED_CONFIRMATION}" != "CLEAR_STAGING_USER_DATA" ]; then
+              echo "Type CLEAR_STAGING_USER_DATA in the confirmation input to clear staging user data." >&2
+              exit 1
+            fi
+          fi
+
       - name: List staging users
         if: ${{ inputs.action == 'list-users' }}
         run: npm run seed:viz-history -- --list-users
@@ -78,3 +91,7 @@ jobs:
       - name: Seed staging visualization history
         if: ${{ inputs.action == 'seed-visualization-data' }}
         run: npm run seed:viz-history -- --email "${SEED_EMAIL}"
+
+      - name: Clear staging user data
+        if: ${{ inputs.action == 'clear-user-data' }}
+        run: npm run reset:user-data -- --email "${SEED_EMAIL}"

--- a/.github/workflows/seed-staging-data.yml
+++ b/.github/workflows/seed-staging-data.yml
@@ -60,14 +60,16 @@ jobs:
             exit 1
           fi
 
+          REQUIRED_CONFIRMATION="MANAGE_STAGING_DATA"
+
           if [ "${SEED_ACTION}" = "seed-visualization-data" ]; then
             if [ -z "${SEED_EMAIL}" ]; then
               echo "email input is required when seeding visualization data." >&2
               exit 1
             fi
 
-            if [ "${SEED_CONFIRMATION}" != "SEED_STAGING" ]; then
-              echo "Type SEED_STAGING in the confirmation input to mutate staging data." >&2
+            if [ "${SEED_CONFIRMATION}" != "${REQUIRED_CONFIRMATION}" ]; then
+              echo "Type ${REQUIRED_CONFIRMATION} in the confirmation input to mutate staging data." >&2
               exit 1
             fi
           fi
@@ -78,8 +80,8 @@ jobs:
               exit 1
             fi
 
-            if [ "${SEED_CONFIRMATION}" != "CLEAR_STAGING_USER_DATA" ]; then
-              echo "Type CLEAR_STAGING_USER_DATA in the confirmation input to clear staging user data." >&2
+            if [ "${SEED_CONFIRMATION}" != "${REQUIRED_CONFIRMATION}" ]; then
+              echo "Type ${REQUIRED_CONFIRMATION} in the confirmation input to clear staging user data." >&2
               exit 1
             fi
           fi

--- a/TODO.md
+++ b/TODO.md
@@ -20,8 +20,9 @@
 - Adjust dark-mode UI contrast, including borders and dividers that are currently too subtle or invisible.
 - Hide nonessential console logging behind a debug-mode flag so production and CI/CD logs stay clean and do not expose sensitive data.
 - Optimize CI so backend tests and frontend builds only run when relevant backend, frontend, dependency, or workflow files change.
+- Consider creating a separate MongoDB Atlas project and staging-only deployment so staging can have its own IP access policy and data-management workflows without affecting production.
 - Add recurring task support, including recurrence rules, generated task instances, and clear UX for editing one occurrence vs the full series.
-- Fix the `Not Found` error when refreshing any page, likely by checking frontend routing fallback behavior and backend/static host configuration for client-side routes.
+- Fix the `Not Found` error when refreshing any page, and document the exact SPA rewrite/fallback requirements for deployed environments like Render (for example `/* -> /index.html`) so browser refreshes and deep links work consistently outside local development.
 - Allow users to view completed tasks and completed goals, with clear filters or dedicated views so completed work remains accessible without crowding active items.
 - Add proper account deletion handling, including confirmation UX and cleanup of all user-owned data and third-party integration records.
 - Revisit time-entry overlap handling. Consider three policy options: `1.` exact-match-only idempotency, where only identical start/end ranges count as duplicates; `2.` reject any overlapping entry for the same task, which prevents double counting but may block legitimate logs; `3.` detect overlap and require user/client resolution, which is the best UX but adds more implementation complexity.

--- a/app-server/package.json
+++ b/app-server/package.json
@@ -9,6 +9,7 @@
     "dev": "cross-env NODE_ENV=development nodemon server.js",
     "start": "node server.js",
     "seed:viz-history": "cross-env NODE_ENV=development node scripts/seedHistoricalVisualizationData.js",
+    "reset:user-data": "cross-env NODE_ENV=development node scripts/resetUserData.js",
     "worker:google-calendar": "cross-env NODE_ENV=development node workers/googleCalendarSyncWorker.js",
     "worker:start": "node workers/googleCalendarSyncWorker.js"
   },

--- a/app-server/scripts/resetUserData.js
+++ b/app-server/scripts/resetUserData.js
@@ -1,0 +1,117 @@
+const path = require('path');
+const dotenv = require('dotenv');
+const mongoose = require('mongoose');
+const connectDB = require('../config/db');
+const User = require('../models/user');
+const Category = require('../models/category');
+const Goal = require('../models/goal');
+const List = require('../models/list');
+const Task = require('../models/task');
+const TimeEntry = require('../models/timeEntry');
+const GoogleCalendarConnection = require('../models/googleCalendarConnection');
+const CalendarSyncJob = require('../models/calendarSyncJob');
+const CalendarSyncMapping = require('../models/calendarSyncMapping');
+
+const envFile = process.env.NODE_ENV === 'production'
+  ? '.env.production'
+  : '.env.development';
+
+dotenv.config({
+  path: path.resolve(__dirname, '..', envFile)
+});
+
+const parseArgs = () => {
+  const args = process.argv.slice(2);
+  const emailIndex = args.indexOf('--email');
+
+  return {
+    email: emailIndex >= 0 ? args[emailIndex + 1] : ''
+  };
+};
+
+const getCollectionCounts = async (userId) => {
+  const [categories, goals, lists, tasks, timeEntries, calendarConnections, calendarSyncJobs, calendarSyncMappings] =
+    await Promise.all([
+      Category.countDocuments({ userId }),
+      Goal.countDocuments({ userId }),
+      List.countDocuments({ userId }),
+      Task.countDocuments({ userId }),
+      TimeEntry.countDocuments({ userId }),
+      GoogleCalendarConnection.countDocuments({ userId }),
+      CalendarSyncJob.countDocuments({ userId }),
+      CalendarSyncMapping.countDocuments({ userId })
+    ]);
+
+  return {
+    categories,
+    goals,
+    lists,
+    tasks,
+    timeEntries,
+    calendarConnections,
+    calendarSyncJobs,
+    calendarSyncMappings
+  };
+};
+
+const logCounts = (label, counts) => {
+  console.log(label);
+  Object.entries(counts).forEach(([key, value]) => {
+    console.log(`- ${key}: ${value}`);
+  });
+};
+
+const resetUserData = async (email) => {
+  const normalizedEmail = String(email || '').trim().toLowerCase();
+
+  if (!normalizedEmail) {
+    throw new Error('Provide an email with --email user@example.com.');
+  }
+
+  const user = await User.findOne({ email: normalizedEmail });
+  if (!user) {
+    throw new Error(
+      `No user found for ${normalizedEmail}. Use the staging list-users workflow action to inspect available accounts.`
+    );
+  }
+
+  const beforeCounts = await getCollectionCounts(user._id);
+  logCounts(`Preparing to clear staging data for ${normalizedEmail}:`, beforeCounts);
+
+  await CalendarSyncMapping.deleteMany({ userId: user._id });
+  await CalendarSyncJob.deleteMany({ userId: user._id });
+  await GoogleCalendarConnection.deleteMany({ userId: user._id });
+  await TimeEntry.deleteMany({ userId: user._id });
+  await Task.deleteMany({ userId: user._id });
+  await List.deleteMany({ userId: user._id });
+  await Goal.deleteMany({ userId: user._id });
+  await Category.deleteMany({ userId: user._id });
+
+  const afterCounts = await getCollectionCounts(user._id);
+  logCounts(`Finished clearing staging data for ${normalizedEmail}:`, afterCounts);
+
+  console.log('The user record was preserved so the account can sign back in without recreation friction.');
+  console.log(
+    'Note: this reset removes app-side Google Calendar connection state and sync metadata, but it does not delete any events that were already written to Google Calendar.'
+  );
+};
+
+const main = async () => {
+  const { email } = parseArgs();
+
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('This reset script is blocked in production.');
+  }
+
+  await connectDB();
+  await resetUserData(email);
+};
+
+main()
+  .catch((err) => {
+    console.error(err.message);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await mongoose.disconnect();
+  });

--- a/docs/manual-e2e-test-pass.md
+++ b/docs/manual-e2e-test-pass.md
@@ -9,6 +9,7 @@ For routine regression work, prioritize the scenarios marked `Partially automate
 - Preferred environment: local or staging with a clean test account.
 - Command reference: see [testing-strategy.md](./testing-strategy.md), especially the `Test commands` section.
 - For automation later, prefer seeded test personas over real Google UI.
+- For staging cleanup, use the `Manage Staging Data` GitHub Actions workflow with the `clear-user-data` action against a dedicated test account before starting a fresh pass.
 - If you want the full dashboard and analytics checks, seed at least:
   - one top-level goal
   - one sub-goal

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -45,6 +45,25 @@ Use these for exploratory testing or the manual E2E pass.
 
 Playwright does not need the app started manually. `playwright.config.js` starts the frontend and backend automatically through its `webServer` entries.
 
+### Manage staging test data
+
+Use the GitHub Actions workflow `Manage Staging Data` when you need to inspect, seed, or clear a dedicated staging test account.
+
+- `list-users`
+  - No confirmation string required.
+- `seed-visualization-data`
+  - Requires an email input and confirmation string:
+  ```text
+  MANAGE_STAGING_DATA
+  ```
+- `clear-user-data`
+  - Requires an email input and confirmation string:
+  ```text
+  MANAGE_STAGING_DATA
+  ```
+
+See [.github/DEPLOYMENT.md](../.github/DEPLOYMENT.md) for the staging workflow details and caveats around Atlas access and Google Calendar cleanup.
+
 ### Run the automated suites
 
 - Backend Jest:


### PR DESCRIPTION
Extend the staging data management flow with a clear-user-data action backed by a new resetUserData script so a dedicated staging account can be cleaned without dropping the shared database.

Also update deployment and manual-test notes, capture the Atlas-project isolation follow-up in TODO.md, and clarify that deployed SPA refresh support depends on explicit rewrite rules such as Render's index.html fallback.