### PR TITLE
Fix visualization chart legend layout

### DIFF
--- a/src/pages/Visualizations.js
+++ b/src/pages/Visualizations.js
@@ -965,26 +965,27 @@ const Visualizations = () => {
                           justifyContent: "center",
                           alignItems: "center",
                           minHeight: 320,
-                          minWidth: 0
+                          minWidth: 0,
+                          overflow: "hidden"
                         }}
                       >
-                      <PieChart
-                        height={320}
-                        margin={{ top: 10, right: 10, bottom: 10, left: 10 }}
-                        series={[
-                          {
-                            data: pieData,
-                            innerRadius: 70,
-                            outerRadius: 110,
-                            paddingAngle: 2,
-                            cornerRadius: 4,
-                            highlightScope: { faded: "global", highlighted: "item" },
-                            faded: { innerRadius: 64, additionalRadius: -6, color: "gray" },
-                            valueFormatter: (value) => `${value.value} hours`
-                          }
-                        ]}
-                        slotProps={{ legend: { hidden: true } }}
-                      />
+                        <PieChart
+                          height={320}
+                          margin={{ top: 10, right: 10, bottom: 10, left: 10 }}
+                          hideLegend
+                          series={[
+                            {
+                              data: pieData,
+                              innerRadius: 70,
+                              outerRadius: 110,
+                              paddingAngle: 2,
+                              cornerRadius: 4,
+                              highlightScope: { faded: "global", highlighted: "item" },
+                              faded: { innerRadius: 64, additionalRadius: -6, color: "gray" },
+                              valueFormatter: (value) => `${value.value} hours`
+                            }
+                          ]}
+                        />
                       </Box>
 
                       <Stack spacing={2}>
@@ -1254,6 +1255,7 @@ const Visualizations = () => {
                     <LineChart
                       height={320}
                       margin={{ top: 20, right: 20, bottom: 30, left: 40 }}
+                      hideLegend
                       xAxis={[
                         {
                           scaleType: "point",
@@ -1267,12 +1269,12 @@ const Visualizations = () => {
                         }
                       ]}
                       grid={{ horizontal: true }}
-                      slotProps={{ legend: { hidden: true } }}
                     />
                   ) : (
                     <BarChart
                       height={320}
                       margin={{ top: 20, right: 20, bottom: 30, left: 40 }}
+                      hideLegend
                       xAxis={[
                         {
                           scaleType: "band",
@@ -1286,7 +1288,6 @@ const Visualizations = () => {
                       ]}
                       series={stackedTrendSeries}
                       grid={{ horizontal: true }}
-                      slotProps={{ legend: { hidden: true } }}
                     />
                   )}
                 </Box>

--- a/src/pages/Visualizations.test.js
+++ b/src/pages/Visualizations.test.js
@@ -13,21 +13,34 @@ import {
   fetchTimeSeries
 } from "../features/analytics/analyticsService";
 
+const mockPieChart = jest.fn(() => <div data-testid="pie-chart">Pie chart</div>);
+const mockLineChart = jest.fn(() => <div data-testid="line-chart">Line chart</div>);
+const mockBarChart = jest.fn(() => <div data-testid="bar-chart">Bar chart</div>);
+
 jest.mock("../features/analytics/analyticsService", () => ({
   fetchTimeByCategory: jest.fn(),
   fetchTimeSeries: jest.fn()
 }));
 
 jest.mock("@mui/x-charts/PieChart", () => ({
-  PieChart: () => <div data-testid="pie-chart">Pie chart</div>
+  PieChart: (props) => {
+    mockPieChart(props);
+    return <div data-testid="pie-chart">Pie chart</div>;
+  }
 }));
 
 jest.mock("@mui/x-charts/LineChart", () => ({
-  LineChart: () => <div data-testid="line-chart">Line chart</div>
+  LineChart: (props) => {
+    mockLineChart(props);
+    return <div data-testid="line-chart">Line chart</div>;
+  }
 }));
 
 jest.mock("@mui/x-charts/BarChart", () => ({
-  BarChart: () => <div data-testid="bar-chart">Bar chart</div>
+  BarChart: (props) => {
+    mockBarChart(props);
+    return <div data-testid="bar-chart">Bar chart</div>;
+  }
 }));
 
 const summaryResponse = {
@@ -245,5 +258,23 @@ describe("Visualizations", () => {
     expect(
       await screen.findAllByText(/no time entry data is available for this range\./i)
     ).toHaveLength(2);
+  });
+
+  test("hides built-in chart legends so the custom summaries own the layout", async () => {
+    await flushUpdates(() => {
+      render(<Visualizations />);
+    });
+
+    expect(await screen.findByTestId("pie-chart")).toBeInTheDocument();
+
+    expect(mockPieChart.mock.calls.some(([props]) => props.hideLegend === true)).toBe(true);
+    expect(mockLineChart.mock.calls.some(([props]) => props.hideLegend === true)).toBe(true);
+
+    await flushUpdates(() => {
+      fireEvent.click(screen.getByRole("button", { name: /^stacked$/i }));
+    });
+
+    expect(await screen.findByTestId("bar-chart")).toBeInTheDocument();
+    expect(mockBarChart.mock.calls.some(([props]) => props.hideLegend === true)).toBe(true);
   });
 });


### PR DESCRIPTION
Switch the visualizations page from the unsupported slotProps legend hiding pattern to the hideLegend prop expected by the installed MUI X chart components so the built-in legends stop stealing layout space.

This prevents the pie chart from being pushed off-center and adds a regression test that verifies the pie, line, and bar charts all render with hideLegend enabled.