### PR TITLE
Mobile Phase 2: Lists (create + detail with tasks)

### DIFF
--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -7,3 +7,14 @@ jest.mock('expo-secure-store', () => ({
   setItemAsync: jest.fn(async () => {}),
   deleteItemAsync: jest.fn(async () => {})
 }));
+
+// useFocusEffect needs a navigation context at runtime; under jest we run the
+// effect like a plain useEffect so screens can be tested in isolation.
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  const React = require('react');
+  return {
+    ...actual,
+    useFocusEffect: (callback) => React.useEffect(callback, [callback])
+  };
+});

--- a/mobile/src/navigation/RootNavigator.js
+++ b/mobile/src/navigation/RootNavigator.js
@@ -14,6 +14,8 @@ import ComingSoonScreen from '../screens/ComingSoonScreen';
 import SettingsScreen from '../screens/SettingsScreen';
 import TaskFormScreen from '../screens/TaskFormScreen';
 import TaskDetailScreen from '../screens/TaskDetailScreen';
+import ListFormScreen from '../screens/ListFormScreen';
+import ListDetailScreen from '../screens/ListDetailScreen';
 
 const Stack = createNativeStackNavigator();
 const Tab = createBottomTabNavigator();
@@ -110,6 +112,16 @@ const RootNavigator = () => {
               options={({ route }) => ({
                 title: route.params?.mode === 'edit' ? 'Edit task' : 'New task'
               })}
+            />
+            <Stack.Screen
+              name="ListDetail"
+              component={ListDetailScreen}
+              options={{ title: 'List' }}
+            />
+            <Stack.Screen
+              name="ListForm"
+              component={ListFormScreen}
+              options={{ title: 'New list' }}
             />
           </>
         ) : (

--- a/mobile/src/screens/ListDetailScreen.js
+++ b/mobile/src/screens/ListDetailScreen.js
@@ -1,0 +1,222 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { FlatList, Pressable, StyleSheet, View } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+import { ActivityIndicator, Button, Card, Chip, Text } from 'react-native-paper';
+import services from '../api/services';
+import ScreenMessage from '../components/ScreenMessage';
+
+const formatHours = (value) => {
+  const hours = Number(value) || 0;
+  return hours.toLocaleString(undefined, { maximumFractionDigits: 2 });
+};
+
+const ListDetailScreen = ({ navigation, route }) => {
+  const listId = route.params?.listId;
+  const [list, setList] = useState(null);
+  const [tasks, setTasks] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const [lists, listTasks] = await Promise.all([
+        services.fetchLists(),
+        services.fetchTasksByListId(listId)
+      ]);
+      const found = Array.isArray(lists)
+        ? lists.find((item) => String(item._id) === String(listId))
+        : null;
+      setList(found || null);
+      setTasks(Array.isArray(listTasks) ? listTasks : []);
+    } catch (err) {
+      setError('Could not load this list.');
+    } finally {
+      setLoading(false);
+    }
+  }, [listId]);
+
+  useFocusEffect(
+    useCallback(() => {
+      load();
+    }, [load])
+  );
+
+  const totalTimeSpent = useMemo(
+    () => tasks.reduce((sum, task) => sum + (Number(task.timeSpent) || 0), 0),
+    [tasks]
+  );
+  const totalEstimatedTime = useMemo(
+    () => tasks.reduce((sum, task) => sum + (Number(task.estimatedCompletionTime) || 0), 0),
+    [tasks]
+  );
+  const completedTasks = useMemo(
+    () => tasks.filter((task) => Boolean(task.isComplete)).length,
+    [tasks]
+  );
+
+  const openTask = useCallback(
+    (task) => navigation.navigate('TaskDetail', { taskId: task._id }),
+    [navigation]
+  );
+
+  const addTask = useCallback(
+    () => navigation.navigate('TaskForm', { mode: 'create', initialListId: listId }),
+    [navigation, listId]
+  );
+
+  if (loading) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  if (error || !list) {
+    return (
+      <ScreenMessage
+        message={error || 'List not found.'}
+        actionLabel="Retry"
+        onAction={load}
+      />
+    );
+  }
+
+  return (
+    <FlatList
+      style={styles.screen}
+      contentContainerStyle={styles.content}
+      data={tasks}
+      keyExtractor={(item) => String(item._id)}
+      ListHeaderComponent={
+        <View>
+          <Card mode="outlined" style={styles.headerCard}>
+            <Card.Content>
+              <Text variant="headlineSmall" style={styles.title}>
+                {list.title || list.name || 'Untitled list'}
+              </Text>
+              {Boolean(list.description) && (
+                <Text variant="bodyMedium" style={styles.description}>
+                  {list.description}
+                </Text>
+              )}
+              <View style={styles.metaRow}>
+                <Chip compact style={styles.chip} icon="format-list-checks">
+                  {tasks.length} {tasks.length === 1 ? 'task' : 'tasks'}
+                </Chip>
+                <Chip compact style={styles.chip} icon="check-circle-outline">
+                  {completedTasks} done
+                </Chip>
+                <Chip compact style={styles.chip} icon="timer-sand">
+                  Est {formatHours(totalEstimatedTime)}h
+                </Chip>
+                <Chip compact style={styles.chip} icon="clock-outline">
+                  Logged {formatHours(totalTimeSpent)}h
+                </Chip>
+              </View>
+            </Card.Content>
+          </Card>
+
+          <Button
+            mode="contained"
+            icon="plus"
+            onPress={addTask}
+            style={styles.addButton}
+          >
+            Add task to list
+          </Button>
+
+          <Text variant="titleMedium" style={styles.sectionHeading}>
+            Tasks
+          </Text>
+        </View>
+      }
+      renderItem={({ item }) => (
+        <Card style={styles.taskCard} mode="outlined">
+          <Pressable onPress={() => openTask(item)}>
+            <Card.Content>
+              <Text
+                variant="titleMedium"
+                style={item.isComplete ? styles.completedTitle : null}
+              >
+                {item.title}
+              </Text>
+              {Boolean(item.description) && (
+                <Text variant="bodySmall" numberOfLines={2} style={styles.taskDescription}>
+                  {item.description}
+                </Text>
+              )}
+            </Card.Content>
+          </Pressable>
+        </Card>
+      )}
+      ListEmptyComponent={
+        <Text variant="bodyMedium" style={styles.emptyTasks}>
+          No tasks in this list yet. Tap "Add task to list" to create one.
+        </Text>
+      }
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1
+  },
+  content: {
+    padding: 16,
+    paddingBottom: 40
+  },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  headerCard: {
+    borderRadius: 16
+  },
+  title: {
+    fontWeight: '700'
+  },
+  description: {
+    marginTop: 10,
+    opacity: 0.85
+  },
+  metaRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginTop: 14
+  },
+  chip: {
+    marginRight: 6,
+    marginTop: 6
+  },
+  addButton: {
+    marginTop: 16
+  },
+  sectionHeading: {
+    marginTop: 22,
+    marginBottom: 6,
+    fontWeight: '700'
+  },
+  taskCard: {
+    marginTop: 10,
+    borderRadius: 14
+  },
+  completedTitle: {
+    textDecorationLine: 'line-through',
+    opacity: 0.6
+  },
+  taskDescription: {
+    marginTop: 2,
+    opacity: 0.8
+  },
+  emptyTasks: {
+    marginTop: 12,
+    opacity: 0.7
+  }
+});
+
+export default ListDetailScreen;

--- a/mobile/src/screens/ListFormScreen.js
+++ b/mobile/src/screens/ListFormScreen.js
@@ -1,0 +1,100 @@
+import React, { useCallback, useState } from 'react';
+import { ScrollView, StyleSheet } from 'react-native';
+import { Button, HelperText, TextInput } from 'react-native-paper';
+import { getListTitleError } from '@productivity/shared';
+import services from '../api/services';
+
+const ListFormScreen = ({ navigation }) => {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = useCallback(async () => {
+    setError('');
+    const titleError = getListTitleError(title);
+    if (titleError) {
+      setError(titleError);
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await services.createList({
+        title: title.trim(),
+        description: description.trim()
+      });
+      navigation.goBack();
+    } catch (err) {
+      setError('Could not create the list. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [title, description, navigation]);
+
+  return (
+    <ScrollView
+      style={styles.screen}
+      contentContainerStyle={styles.content}
+      keyboardShouldPersistTaps="handled"
+    >
+      <TextInput
+        label="Title"
+        accessibilityLabel="Title"
+        value={title}
+        onChangeText={setTitle}
+        mode="outlined"
+        style={styles.input}
+        autoFocus
+      />
+
+      <TextInput
+        label="Description"
+        accessibilityLabel="Description"
+        value={description}
+        onChangeText={setDescription}
+        mode="outlined"
+        multiline
+        numberOfLines={4}
+        style={[styles.input, styles.multiline]}
+      />
+
+      {Boolean(error) && (
+        <HelperText type="error" visible>
+          {error}
+        </HelperText>
+      )}
+
+      <Button
+        mode="contained"
+        onPress={handleSubmit}
+        loading={submitting}
+        disabled={submitting}
+        style={styles.submit}
+      >
+        Create list
+      </Button>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1
+  },
+  content: {
+    padding: 16,
+    paddingBottom: 40
+  },
+  input: {
+    marginTop: 8
+  },
+  multiline: {
+    minHeight: 100
+  },
+  submit: {
+    marginTop: 20
+  }
+});
+
+export default ListFormScreen;

--- a/mobile/src/screens/ListsScreen.js
+++ b/mobile/src/screens/ListsScreen.js
@@ -1,11 +1,11 @@
 import React, { useCallback, useState } from 'react';
-import { FlatList, RefreshControl, StyleSheet, View } from 'react-native';
+import { FlatList, Pressable, RefreshControl, StyleSheet, View } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
-import { ActivityIndicator, Card, Text } from 'react-native-paper';
+import { ActivityIndicator, Card, FAB, Text } from 'react-native-paper';
 import services from '../api/services';
 import ScreenMessage from '../components/ScreenMessage';
 
-const ListsScreen = () => {
+const ListsScreen = ({ navigation }) => {
   const [lists, setLists] = useState([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -32,6 +32,16 @@ const ListsScreen = () => {
     }, [load])
   );
 
+  const openList = useCallback(
+    (list) => navigation.navigate('ListDetail', { listId: list._id }),
+    [navigation]
+  );
+
+  const openCreate = useCallback(
+    () => navigation.navigate('ListForm'),
+    [navigation]
+  );
+
   if (loading) {
     return (
       <View style={styles.centered}>
@@ -44,48 +54,59 @@ const ListsScreen = () => {
     return <ScreenMessage message={error} actionLabel="Retry" onAction={load} />;
   }
 
-  if (lists.length === 0) {
-    return (
-      <ScreenMessage
-        message="No lists yet. Create one from the web app to see it here."
-        actionLabel="Refresh"
-        onAction={load}
-      />
-    );
-  }
-
   return (
-    <FlatList
-      contentContainerStyle={styles.list}
-      data={lists}
-      keyExtractor={(item) => String(item._id)}
-      renderItem={({ item }) => (
-        <Card style={styles.card} mode="outlined">
-          <Card.Content>
-            <Text variant="titleMedium">{item.name || item.title || 'Untitled list'}</Text>
-            {Boolean(item.description) && (
-              <Text variant="bodySmall" style={styles.description}>
-                {item.description}
-              </Text>
-            )}
-          </Card.Content>
-        </Card>
-      )}
-      refreshControl={
-        <RefreshControl
-          refreshing={refreshing}
-          onRefresh={() => load({ isRefresh: true })}
+    <View style={styles.container}>
+      {lists.length === 0 ? (
+        <ScreenMessage
+          message="No lists yet. Tap + to create your first list."
+          actionLabel="Refresh"
+          onAction={load}
         />
-      }
-    />
+      ) : (
+        <FlatList
+          contentContainerStyle={styles.list}
+          data={lists}
+          keyExtractor={(item) => String(item._id)}
+          renderItem={({ item }) => (
+            <Card style={styles.card} mode="outlined">
+              <Pressable onPress={() => openList(item)}>
+                <Card.Content>
+                  <Text variant="titleMedium">
+                    {item.title || item.name || 'Untitled list'}
+                  </Text>
+                  {Boolean(item.description) && (
+                    <Text variant="bodySmall" style={styles.description}>
+                      {item.description}
+                    </Text>
+                  )}
+                </Card.Content>
+              </Pressable>
+            </Card>
+          )}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={() => load({ isRefresh: true })}
+            />
+          }
+        />
+      )}
+      <FAB icon="plus" style={styles.fab} onPress={openCreate} accessibilityLabel="Create list" />
+    </View>
   );
 };
 
 const styles = StyleSheet.create({
+  container: { flex: 1 },
   centered: { flex: 1, justifyContent: 'center', alignItems: 'center' },
   list: { padding: 12 },
   card: { marginBottom: 10, borderRadius: 14 },
-  description: { marginTop: 2, opacity: 0.8 }
+  description: { marginTop: 2, opacity: 0.8 },
+  fab: {
+    position: 'absolute',
+    right: 16,
+    bottom: 16
+  }
 });
 
 export default ListsScreen;

--- a/mobile/src/screens/TaskFormScreen.js
+++ b/mobile/src/screens/TaskFormScreen.js
@@ -35,7 +35,9 @@ const TaskFormScreen = ({ navigation, route }) => {
   const [targetCompletionDate, setTargetCompletionDate] = useState(
     task?.targetCompletionDate ? dayjs(task.targetCompletionDate) : null
   );
-  const [listId, setListId] = useState(task?.listId || task?.list?._id || null);
+  const [listId, setListId] = useState(
+    task?.listId || task?.list?._id || route.params?.initialListId || null
+  );
   const [parentGoalId, setParentGoalId] = useState(
     task?.parentGoalId || task?.parentGoal?._id || null
   );

--- a/mobile/src/screens/__tests__/ListDetailScreen.test.js
+++ b/mobile/src/screens/__tests__/ListDetailScreen.test.js
@@ -1,0 +1,80 @@
+/* eslint-env jest */
+import React from 'react';
+import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+import { renderWithPaper } from '../../test-utils';
+import ListDetailScreen from '../ListDetailScreen';
+import services from '../../api/services';
+
+jest.mock('../../api/services', () => ({
+  fetchLists: jest.fn(),
+  fetchTasksByListId: jest.fn()
+}));
+
+const makeNavigation = () => ({ goBack: jest.fn(), navigate: jest.fn() });
+
+describe('ListDetailScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the list details and its tasks', async () => {
+    services.fetchLists.mockResolvedValue([
+      { _id: 'list1', title: 'Groceries', description: 'weekly run' }
+    ]);
+    services.fetchTasksByListId.mockResolvedValue([
+      { _id: 't1', title: 'Buy milk', estimatedCompletionTime: 1, timeSpent: 0.5, isComplete: true },
+      { _id: 't2', title: 'Buy bread', estimatedCompletionTime: 2, timeSpent: 0, isComplete: false }
+    ]);
+
+    renderWithPaper(
+      <ListDetailScreen navigation={makeNavigation()} route={{ params: { listId: 'list1' } }} />
+    );
+
+    expect(await screen.findByText('Groceries')).toBeTruthy();
+    expect(screen.getByText('weekly run')).toBeTruthy();
+    expect(screen.getByText('Buy milk')).toBeTruthy();
+    expect(screen.getByText('Buy bread')).toBeTruthy();
+    expect(screen.getByText('2 tasks')).toBeTruthy();
+    expect(screen.getByText('1 done')).toBeTruthy();
+  });
+
+  it('opens a task when its card is pressed', async () => {
+    const navigation = makeNavigation();
+    services.fetchLists.mockResolvedValue([{ _id: 'list1', title: 'Groceries' }]);
+    services.fetchTasksByListId.mockResolvedValue([{ _id: 't1', title: 'Buy milk' }]);
+
+    renderWithPaper(
+      <ListDetailScreen navigation={navigation} route={{ params: { listId: 'list1' } }} />
+    );
+
+    fireEvent.press(await screen.findByText('Buy milk'));
+    expect(navigation.navigate).toHaveBeenCalledWith('TaskDetail', { taskId: 't1' });
+  });
+
+  it('navigates to the task form with the list preselected', async () => {
+    const navigation = makeNavigation();
+    services.fetchLists.mockResolvedValue([{ _id: 'list1', title: 'Groceries' }]);
+    services.fetchTasksByListId.mockResolvedValue([]);
+
+    renderWithPaper(
+      <ListDetailScreen navigation={navigation} route={{ params: { listId: 'list1' } }} />
+    );
+
+    fireEvent.press(await screen.findByText('Add task to list'));
+    expect(navigation.navigate).toHaveBeenCalledWith('TaskForm', {
+      mode: 'create',
+      initialListId: 'list1'
+    });
+  });
+
+  it('shows an error state when loading fails', async () => {
+    services.fetchLists.mockRejectedValue(new Error('boom'));
+    services.fetchTasksByListId.mockRejectedValue(new Error('boom'));
+
+    renderWithPaper(
+      <ListDetailScreen navigation={makeNavigation()} route={{ params: { listId: 'list1' } }} />
+    );
+
+    expect(await screen.findByText('Could not load this list.')).toBeTruthy();
+  });
+});

--- a/mobile/src/screens/__tests__/ListFormScreen.test.js
+++ b/mobile/src/screens/__tests__/ListFormScreen.test.js
@@ -1,0 +1,45 @@
+/* eslint-env jest */
+import React from 'react';
+import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+import { renderWithPaper } from '../../test-utils';
+import ListFormScreen from '../ListFormScreen';
+import services from '../../api/services';
+
+jest.mock('../../api/services', () => ({
+  createList: jest.fn(async () => ({ data: { _id: 'list1' } }))
+}));
+
+const makeNavigation = () => ({ goBack: jest.fn(), navigate: jest.fn() });
+
+describe('ListFormScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a list with the entered values', async () => {
+    const navigation = makeNavigation();
+    renderWithPaper(<ListFormScreen navigation={navigation} route={{ params: {} }} />);
+
+    fireEvent.changeText(screen.getByLabelText('Title'), '  Groceries  ');
+    fireEvent.changeText(screen.getByLabelText('Description'), '  weekly run  ');
+    fireEvent.press(screen.getByText('Create list'));
+
+    await waitFor(() => expect(services.createList).toHaveBeenCalledTimes(1));
+    expect(services.createList.mock.calls[0][0]).toEqual({
+      title: 'Groceries',
+      description: 'weekly run'
+    });
+    await waitFor(() => expect(navigation.goBack).toHaveBeenCalled());
+  });
+
+  it('blocks submit and shows an error when the title is empty', async () => {
+    const navigation = makeNavigation();
+    renderWithPaper(<ListFormScreen navigation={navigation} route={{ params: {} }} />);
+
+    fireEvent.press(screen.getByText('Create list'));
+
+    expect(await screen.findByText('List title is required.')).toBeTruthy();
+    expect(services.createList).not.toHaveBeenCalled();
+    expect(navigation.goBack).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/validation.js
+++ b/packages/shared/src/validation.js
@@ -77,6 +77,13 @@ const getTimeEntryDurationHours = ({ startedAt, endedAt }) => {
   return Math.round((endedAt.diff(startedAt, 'minute', true) / 60) * 100) / 100;
 };
 
+const getListTitleError = (value) => {
+  if (!value || !String(value).trim()) {
+    return 'List title is required.';
+  }
+  return null;
+};
+
 const getGoalTargetCompletionDateError = ({
   targetCompletionDate,
   now,
@@ -135,6 +142,7 @@ module.exports = {
   parseTaskEstimateHours,
   getTimeEntryRangeError,
   getTimeEntryDurationHours,
+  getListTitleError,
   getGoalTargetCompletionDateError,
   getGoalTargetCompletionDateMinDateTime,
   getGoalEstimateHoursError,

--- a/packages/shared/src/validation.test.js
+++ b/packages/shared/src/validation.test.js
@@ -10,7 +10,8 @@ const {
   getTaskEstimateHoursError,
   parseTaskEstimateHours,
   getTimeEntryRangeError,
-  getTimeEntryDurationHours
+  getTimeEntryDurationHours,
+  getListTitleError
 } = require('./validation');
 
 const now = dayjs('2026-01-01T12:00:00Z');
@@ -143,5 +144,17 @@ test('time entry validation', async (t) => {
   await t.test('accepts a valid range and computes duration hours', () => {
     assert.equal(getTimeEntryRangeError({ startedAt: start, endedAt: end, now }), null);
     assert.equal(getTimeEntryDurationHours({ startedAt: start, endedAt: end }), 1.5);
+  });
+});
+
+test('list title validation', async (t) => {
+  await t.test('rejects an empty or whitespace-only title', () => {
+    assert.match(getListTitleError(''), /title is required/i);
+    assert.match(getListTitleError('   '), /title is required/i);
+    assert.match(getListTitleError(undefined), /title is required/i);
+  });
+
+  await t.test('accepts a non-empty title', () => {
+    assert.equal(getListTitleError('Groceries'), null);
   });
 });


### PR DESCRIPTION
## Summary
Adds Lists to the mobile app at parity with the web app. Web Lists support create + view (the backend only exposes `GET /lists`, `POST /lists`, and `GET /tasks/list/:listId` — there is no list update/delete), so this mirrors exactly that: create a list, browse lists, open a list to see its tasks and stats.

What changed:
- **`ListsScreen`** (was read-only): cards are now tappable → `ListDetail`, and a `+` FAB → `ListForm`. Empty-state copy updated (no longer "create one from the web app").
- **`ListFormScreen`** (new): title (required) + description; creates via `services.createList` then `goBack`.
- **`ListDetailScreen`** (new): loads the list (`fetchLists` → find by id) and its tasks (`fetchTasksByListId`); shows title/description, stat chips (task count, done, est/logged hours), a tappable task list → `TaskDetail`, and an "Add task to list" button.
- **`TaskFormScreen`**: create mode now honors a preselected list:
  ```diff
  - useState(task?.listId || task?.list?._id || null)
  + useState(task?.listId || task?.list?._id || route.params?.initialListId || null)
  ```
  so "Add task to list" opens the task form with that list already selected.
- **shared `getListTitleError(value)`**: framework-agnostic title-required validator, reused by the mobile form (same rule the web `ListForm` enforces inline).
- **`jest.setup.js`**: global shim so `useFocusEffect` runs like `useEffect` under jest (screens using it can be unit-tested without a `NavigationContainer`).

## Testing
- Shared: `npm run test:shared` — 48 pass (added `getListTitleError` cases).
- Mobile: `npm test` — 13 pass, including new `ListFormScreen` (create + empty-title validation) and `ListDetailScreen` (renders list + tasks + stats, task tap → detail, add-task preselect, error state).
- Manual: verified on the Android emulator against the live backend (create list → appears in list → open detail → add task preselected to the list → task shows under the list).

Note: no backend changes — list rename/delete isn't part of web parity because the API doesn't support it.

Link to Devin session: https://outpostai.devinenterprise.com/sessions/ff64e9512115425a99f6f54925e0d377
Requested by: @ysingh97