### PR TITLE
Mobile Phase 4: Calendar (week/month agenda of goals + tasks)

### DIFF
--- a/mobile/src/navigation/RootNavigator.js
+++ b/mobile/src/navigation/RootNavigator.js
@@ -10,6 +10,7 @@ import SignInScreen from '../screens/SignInScreen';
 import BoardScreen from '../screens/BoardScreen';
 import ListsScreen from '../screens/ListsScreen';
 import GoalsScreen from '../screens/GoalsScreen';
+import CalendarScreen from '../screens/CalendarScreen';
 import ComingSoonScreen from '../screens/ComingSoonScreen';
 import SettingsScreen from '../screens/SettingsScreen';
 import TaskFormScreen from '../screens/TaskFormScreen';
@@ -51,7 +52,7 @@ const MainTabs = ({ navigation }) => (
     <Tab.Screen name="Board" component={BoardScreen} />
     <Tab.Screen name="Lists" component={ListsScreen} />
     <Tab.Screen name="Goals" component={GoalsScreen} />
-    <Tab.Screen name="Calendar" component={ComingSoonScreen} />
+    <Tab.Screen name="Calendar" component={CalendarScreen} />
     <Tab.Screen name="Analytics" component={ComingSoonScreen} />
   </Tab.Navigator>
 );

--- a/mobile/src/screens/CalendarScreen.js
+++ b/mobile/src/screens/CalendarScreen.js
@@ -1,0 +1,425 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { SectionList, StyleSheet, View } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+import dayjs from 'dayjs';
+import isBetween from 'dayjs/plugin/isBetween';
+import {
+  ActivityIndicator,
+  Button,
+  Card,
+  Checkbox,
+  Chip,
+  Divider,
+  SegmentedButtons,
+  Text
+} from 'react-native-paper';
+import {
+  UNASSIGNED_ID,
+  resolveTopLevelGoalIds,
+  buildGoalColorMap,
+  buildGoalCalendarItems,
+  buildTaskCalendarItems,
+  describeCalendarGroup
+} from '@productivity/shared';
+import services from '../api/services';
+import ScreenMessage from '../components/ScreenMessage';
+
+dayjs.extend(isBetween);
+
+const formatDayKey = (value) => dayjs(value).format('YYYY-MM-DD');
+
+const CalendarScreen = ({ navigation }) => {
+  const [goals, setGoals] = useState([]);
+  const [tasks, setTasks] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [viewMode, setViewMode] = useState('week');
+  const [activeDate, setActiveDate] = useState(() => dayjs());
+  const [selectedGoalIds, setSelectedGoalIds] = useState(() => new Set());
+  const [hasUserFiltered, setHasUserFiltered] = useState(false);
+  const [showGoals, setShowGoals] = useState(true);
+  const [showTasks, setShowTasks] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const [goalData, taskData] = await Promise.all([
+        services.fetchGoals(),
+        services.fetchTasks()
+      ]);
+      setGoals(Array.isArray(goalData) ? goalData : []);
+      setTasks(Array.isArray(taskData) ? taskData : []);
+    } catch (err) {
+      setError('Unable to load calendar data right now.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      load();
+    }, [load])
+  );
+
+  const today = useMemo(() => dayjs(), []);
+
+  const viewStart = useMemo(
+    () =>
+      viewMode === 'month'
+        ? activeDate.startOf('month')
+        : activeDate.startOf('week'),
+    [activeDate, viewMode]
+  );
+
+  const viewEnd = useMemo(
+    () =>
+      viewMode === 'month' ? activeDate.endOf('month') : activeDate.endOf('week'),
+    [activeDate, viewMode]
+  );
+
+  const rangeLabel = useMemo(() => {
+    if (viewMode === 'month') {
+      return activeDate.format('MMMM YYYY');
+    }
+    return `${viewStart.format('MMM D')} - ${viewEnd.format('MMM D, YYYY')}`;
+  }, [activeDate, viewEnd, viewMode, viewStart]);
+
+  const goalsById = useMemo(() => {
+    const map = new Map();
+    goals.forEach((goal) => map.set(String(goal._id), goal));
+    return map;
+  }, [goals]);
+
+  const topLevelByGoalId = useMemo(() => resolveTopLevelGoalIds(goals), [goals]);
+
+  const goalColorMap = useMemo(
+    () => buildGoalColorMap(goals, topLevelByGoalId),
+    [goals, topLevelByGoalId]
+  );
+
+  const goalsInRange = useMemo(
+    () =>
+      goals.filter(
+        (goal) =>
+          goal.targetCompletionDate &&
+          dayjs(goal.targetCompletionDate).isBetween(viewStart, viewEnd, null, '[]')
+      ),
+    [goals, viewEnd, viewStart]
+  );
+
+  const tasksInRange = useMemo(
+    () =>
+      tasks.filter(
+        (task) =>
+          task.targetCompletionDate &&
+          dayjs(task.targetCompletionDate).isBetween(viewStart, viewEnd, null, '[]')
+      ),
+    [tasks, viewEnd, viewStart]
+  );
+
+  const itemsForDisplay = useMemo(() => {
+    const items = [];
+    if (showGoals) {
+      items.push(...buildGoalCalendarItems(goalsInRange, topLevelByGoalId));
+    }
+    if (showTasks) {
+      items.push(...buildTaskCalendarItems(tasksInRange, topLevelByGoalId));
+    }
+    return items;
+  }, [goalsInRange, showGoals, showTasks, tasksInRange, topLevelByGoalId]);
+
+  const availableGoalIds = useMemo(() => {
+    const ids = new Set();
+    itemsForDisplay.forEach((item) => ids.add(item.topLevelId || UNASSIGNED_ID));
+    return Array.from(ids);
+  }, [itemsForDisplay]);
+
+  const availableGoals = useMemo(
+    () =>
+      availableGoalIds
+        .map((id) => describeCalendarGroup(id, goalsById))
+        .sort((a, b) => {
+          if (a.isPseudo) return 1;
+          if (b.isPseudo) return -1;
+          return a.title.localeCompare(b.title, undefined, { sensitivity: 'base' });
+        }),
+    [availableGoalIds, goalsById]
+  );
+
+  useEffect(() => {
+    setSelectedGoalIds((prev) => {
+      if (availableGoalIds.length === 0) {
+        return new Set();
+      }
+      if (!hasUserFiltered) {
+        return new Set(availableGoalIds);
+      }
+      const next = new Set();
+      availableGoalIds.forEach((id) => {
+        if (prev.has(id)) next.add(id);
+      });
+      return next;
+    });
+  }, [availableGoalIds, hasUserFiltered]);
+
+  const sections = useMemo(() => {
+    const byDay = new Map();
+    itemsForDisplay
+      .filter((item) => selectedGoalIds.has(item.topLevelId || UNASSIGNED_ID))
+      .forEach((item) => {
+        const key = formatDayKey(item.date);
+        if (!byDay.has(key)) byDay.set(key, []);
+        byDay.get(key).push(item);
+      });
+
+    return Array.from(byDay.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, items]) => ({
+        key,
+        title: dayjs(key).format('ddd, MMM D'),
+        isToday: dayjs(key).isSame(today, 'day'),
+        data: items.sort((a, b) => {
+          if (a.type === b.type) {
+            return (a.title || '').localeCompare(b.title || '', undefined, {
+              sensitivity: 'base'
+            });
+          }
+          return a.type === 'goal' ? -1 : 1;
+        })
+      }));
+  }, [itemsForDisplay, selectedGoalIds, today]);
+
+  const shift = (direction) =>
+    setActiveDate((prev) =>
+      viewMode === 'month'
+        ? prev.add(direction, 'month')
+        : prev.add(direction, 'week')
+    );
+
+  const toggleGoal = (goalId) => {
+    setHasUserFiltered(true);
+    setSelectedGoalIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(goalId)) next.delete(goalId);
+      else next.add(goalId);
+      return next;
+    });
+  };
+
+  const selectAll = () => {
+    setHasUserFiltered(false);
+    setSelectedGoalIds(new Set(availableGoalIds));
+  };
+
+  const clearAll = () => {
+    setHasUserFiltered(true);
+    setSelectedGoalIds(new Set());
+  };
+
+  const openItem = (item) => {
+    if (item.type === 'goal') {
+      navigation.navigate('GoalDetail', { goalId: item.id });
+    } else {
+      navigation.navigate('TaskDetail', { taskId: item.id });
+    }
+  };
+
+  const header = (
+    <View style={styles.header}>
+      <SegmentedButtons
+        value={viewMode}
+        onValueChange={setViewMode}
+        buttons={[
+          { value: 'week', label: 'Week' },
+          { value: 'month', label: 'Month' }
+        ]}
+      />
+
+      <View style={styles.navRow}>
+        <Button mode="outlined" compact onPress={() => shift(-1)}>
+          Prev
+        </Button>
+        <Button mode="outlined" compact onPress={() => setActiveDate(dayjs())}>
+          Today
+        </Button>
+        <Button mode="outlined" compact onPress={() => shift(1)}>
+          Next
+        </Button>
+      </View>
+
+      <Text variant="titleMedium" style={styles.rangeLabel}>
+        {rangeLabel}
+      </Text>
+
+      <View style={styles.toggleRow}>
+        <Checkbox.Item
+          label="Goals"
+          testID="toggle-goals"
+          position="leading"
+          status={showGoals ? 'checked' : 'unchecked'}
+          onPress={() => setShowGoals((prev) => !prev)}
+          style={styles.toggleItem}
+        />
+        <Checkbox.Item
+          label="Tasks"
+          testID="toggle-tasks"
+          position="leading"
+          status={showTasks ? 'checked' : 'unchecked'}
+          onPress={() => setShowTasks((prev) => !prev)}
+          style={styles.toggleItem}
+        />
+      </View>
+
+      {availableGoals.length > 0 && (
+        <View style={styles.filters}>
+          <View style={styles.filterHeaderRow}>
+            <Text variant="labelLarge">Goal trees</Text>
+            <View style={styles.filterActions}>
+              <Button compact onPress={selectAll}>
+                All
+              </Button>
+              <Button compact onPress={clearAll}>
+                Clear
+              </Button>
+            </View>
+          </View>
+          <View style={styles.chips}>
+            {availableGoals.map((goal) => {
+              const selected = selectedGoalIds.has(goal.id);
+              const color = goalColorMap.get(goal.id) || '#64748b';
+              return (
+                <Chip
+                  key={goal.id}
+                  testID={`filter-chip-${goal.id}`}
+                  compact
+                  selected={selected}
+                  showSelectedCheck={false}
+                  onPress={() => toggleGoal(goal.id)}
+                  style={[
+                    styles.chip,
+                    { borderColor: color },
+                    selected && { backgroundColor: `${color}22` }
+                  ]}
+                  icon={() => <View style={[styles.dot, { backgroundColor: color }]} />}
+                >
+                  {goal.title}
+                </Chip>
+              );
+            })}
+          </View>
+        </View>
+      )}
+      <Divider style={styles.divider} />
+    </View>
+  );
+
+  if (loading) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  if (error) {
+    return <ScreenMessage message={error} actionLabel="Retry" onAction={load} />;
+  }
+
+  return (
+    <View style={styles.container}>
+      <SectionList
+        sections={sections}
+        keyExtractor={(item) => `${item.type}-${item.id}`}
+        ListHeaderComponent={header}
+        stickySectionHeadersEnabled={false}
+        initialNumToRender={50}
+        contentContainerStyle={styles.listContent}
+        ListEmptyComponent={
+          <View style={styles.empty}>
+            <Text variant="bodyMedium" style={styles.emptyText}>
+              No goals or tasks due in this range.
+            </Text>
+          </View>
+        }
+        renderSectionHeader={({ section }) => (
+          <Text
+            variant="labelLarge"
+            style={[styles.sectionHeader, section.isToday && styles.sectionHeaderToday]}
+          >
+            {section.title}
+            {section.isToday ? ' · Today' : ''}
+          </Text>
+        )}
+        renderItem={({ item }) => {
+          const color = goalColorMap.get(item.topLevelId) || '#64748b';
+          return (
+            <Card
+              mode="outlined"
+              testID={`calendar-item-${item.type}-${item.id}`}
+              style={[styles.itemCard, { borderLeftColor: color }]}
+              onPress={() => openItem(item)}
+            >
+              <Card.Content style={styles.itemContent}>
+                <View style={styles.itemText}>
+                  <Text variant="bodyMedium" numberOfLines={2}>
+                    {item.title}
+                  </Text>
+                  <Text variant="labelSmall" style={styles.itemMeta}>
+                    {item.type === 'goal'
+                      ? item.isTopLevel
+                        ? 'Top-level goal'
+                        : 'Goal'
+                      : 'Task'}
+                  </Text>
+                </View>
+                <Chip compact style={styles.typeChip}>
+                  {item.type === 'goal' ? 'Goal' : 'Task'}
+                </Chip>
+              </Card.Content>
+            </Card>
+          );
+        }}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  centered: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  listContent: { padding: 12, paddingBottom: 32 },
+  header: { gap: 12, marginBottom: 4 },
+  navRow: { flexDirection: 'row', gap: 8 },
+  rangeLabel: { textAlign: 'center' },
+  toggleRow: { flexDirection: 'row', justifyContent: 'space-around' },
+  toggleItem: { flex: 1, paddingHorizontal: 0 },
+  filters: { gap: 8 },
+  filterHeaderRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between'
+  },
+  filterActions: { flexDirection: 'row' },
+  chips: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  chip: { borderWidth: 1 },
+  dot: { width: 10, height: 10, borderRadius: 5 },
+  divider: { marginTop: 4 },
+  sectionHeader: { marginTop: 16, marginBottom: 8, opacity: 0.7 },
+  sectionHeaderToday: { opacity: 1, fontWeight: '700' },
+  itemCard: { marginBottom: 8, borderLeftWidth: 4, borderRadius: 12 },
+  itemContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8
+  },
+  itemText: { flex: 1 },
+  itemMeta: { marginTop: 2, opacity: 0.6 },
+  typeChip: { alignSelf: 'center' },
+  empty: { padding: 24, alignItems: 'center' },
+  emptyText: { opacity: 0.6 }
+});
+
+export default CalendarScreen;

--- a/mobile/src/screens/__tests__/CalendarScreen.test.js
+++ b/mobile/src/screens/__tests__/CalendarScreen.test.js
@@ -1,0 +1,114 @@
+/* eslint-env jest */
+import React from 'react';
+import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+import { renderWithPaper } from '../../test-utils';
+import CalendarScreen from '../CalendarScreen';
+import services from '../../api/services';
+
+jest.mock('../../api/services', () => ({
+  fetchGoals: jest.fn(),
+  fetchTasks: jest.fn()
+}));
+
+const makeNavigation = () => ({
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  push: jest.fn()
+});
+
+describe('CalendarScreen', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-01-15T12:00:00.000Z'));
+    jest.clearAllMocks();
+
+    services.fetchGoals.mockResolvedValue([
+      {
+        _id: 'goal-root-1',
+        title: 'Launch Goal',
+        parentGoalId: null,
+        targetCompletionDate: '2026-01-14T10:00:00.000Z'
+      },
+      {
+        _id: 'goal-child-1',
+        title: 'Launch Subgoal',
+        parentGoalId: 'goal-root-1',
+        targetCompletionDate: '2026-01-16T10:00:00.000Z'
+      },
+      {
+        _id: 'goal-root-2',
+        title: 'Health Goal',
+        parentGoalId: null,
+        targetCompletionDate: '2026-01-15T10:00:00.000Z'
+      }
+    ]);
+    services.fetchTasks.mockResolvedValue([
+      {
+        _id: 'task-1',
+        title: 'Launch Task',
+        parentGoalId: 'goal-child-1',
+        targetCompletionDate: '2026-01-13T10:00:00.000Z'
+      },
+      {
+        _id: 'task-2',
+        title: 'Standalone Task',
+        parentGoalId: null,
+        targetCompletionDate: '2026-01-17T10:00:00.000Z'
+      }
+    ]);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders due goals and tasks for the current week', async () => {
+    renderWithPaper(<CalendarScreen navigation={makeNavigation()} />);
+
+    expect(await screen.findByText('Jan 11 - Jan 17, 2026')).toBeTruthy();
+    expect(await screen.findByTestId('calendar-item-goal-goal-root-1')).toBeTruthy();
+    expect(await screen.findByText('Launch Task')).toBeTruthy();
+    expect(await screen.findByText('Standalone Task')).toBeTruthy();
+  });
+
+  it('hides tasks when the Tasks toggle is turned off', async () => {
+    renderWithPaper(<CalendarScreen navigation={makeNavigation()} />);
+
+    expect(await screen.findByText('Launch Task')).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId('toggle-tasks'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Launch Task')).toBeNull();
+      expect(screen.queryByText('Standalone Task')).toBeNull();
+    });
+    expect(screen.getByTestId('calendar-item-goal-goal-root-1')).toBeTruthy();
+  });
+
+  it('filters by goal tree when a chip is toggled off', async () => {
+    renderWithPaper(<CalendarScreen navigation={makeNavigation()} />);
+
+    expect(await screen.findByText('Launch Task')).toBeTruthy();
+
+    // Toggle off the "Launch Goal" tree; its goals + linked tasks disappear,
+    // the unassigned task stays.
+    fireEvent.press(screen.getByTestId('filter-chip-goal-root-1'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Launch Task')).toBeNull();
+      expect(screen.getByText('Standalone Task')).toBeTruthy();
+    });
+  });
+
+  it('navigates to goal and task detail on item press', async () => {
+    const navigation = makeNavigation();
+    renderWithPaper(<CalendarScreen navigation={navigation} />);
+
+    await screen.findByText('Launch Task');
+    fireEvent.press(screen.getByTestId('calendar-item-task-task-1'));
+    expect(navigation.navigate).toHaveBeenCalledWith('TaskDetail', { taskId: 'task-1' });
+
+    fireEvent.press(screen.getByTestId('calendar-item-goal-goal-root-2'));
+    expect(navigation.navigate).toHaveBeenCalledWith('GoalDetail', { goalId: 'goal-root-2' });
+  });
+});

--- a/packages/shared/src/calendarModel.js
+++ b/packages/shared/src/calendarModel.js
@@ -1,0 +1,140 @@
+const { toGoalId } = require('./goalHierarchy');
+
+const UNASSIGNED_ID = 'unassigned';
+const UNASSIGNED_COLOR = '#64748b';
+
+const CALENDAR_GOAL_COLORS = [
+  '#1d4ed8',
+  '#059669',
+  '#ea580c',
+  '#e11d48',
+  '#0f766e',
+  '#0ea5e9',
+  '#84cc16',
+  '#16a34a',
+  '#f59e0b',
+  '#dc2626'
+];
+
+const buildGoalsById = (goals = []) => {
+  const map = new Map();
+  goals.forEach((goal) => {
+    const id = toGoalId(goal?._id);
+    if (id) {
+      map.set(id, goal);
+    }
+  });
+  return map;
+};
+
+// Maps every goal id to the id of the top-level goal (root) of its tree.
+// Handles missing parents and parent cycles gracefully (a goal in a cycle
+// resolves to itself).
+const resolveTopLevelGoalIds = (goals = []) => {
+  const goalsById = buildGoalsById(goals);
+  const topLevelById = new Map();
+
+  const resolve = (goalId, trail) => {
+    const id = toGoalId(goalId);
+    if (!id) return null;
+    if (topLevelById.has(id)) {
+      return topLevelById.get(id);
+    }
+    if (trail.has(id)) {
+      topLevelById.set(id, id);
+      return id;
+    }
+    const goal = goalsById.get(id);
+    if (!goal || !goal.parentGoalId) {
+      topLevelById.set(id, id);
+      return id;
+    }
+    trail.add(id);
+    const rootId = resolve(goal.parentGoalId, trail);
+    topLevelById.set(id, rootId || id);
+    return topLevelById.get(id);
+  };
+
+  goalsById.forEach((_goal, id) => {
+    resolve(id, new Set());
+  });
+
+  return topLevelById;
+};
+
+const getTopLevelGoalId = (goalId, topLevelById) => {
+  const id = toGoalId(goalId);
+  if (!id) return null;
+  return topLevelById.get(id) || id;
+};
+
+// Assigns a stable color to each top-level goal tree, ordered by title so the
+// mapping is deterministic across renders/platforms.
+const buildGoalColorMap = (goals = [], topLevelById) => {
+  const resolved = topLevelById || resolveTopLevelGoalIds(goals);
+  const goalsById = buildGoalsById(goals);
+
+  const topLevelIds = new Set();
+  goalsById.forEach((_goal, id) => {
+    topLevelIds.add(getTopLevelGoalId(id, resolved) || id);
+  });
+
+  const sorted = Array.from(topLevelIds)
+    .map((id) => ({ id, title: goalsById.get(id)?.title || 'Unknown goal' }))
+    .sort((a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: 'base' }));
+
+  const colorMap = new Map();
+  sorted.forEach((goal, index) => {
+    colorMap.set(goal.id, CALENDAR_GOAL_COLORS[index % CALENDAR_GOAL_COLORS.length]);
+  });
+  colorMap.set(UNASSIGNED_ID, UNASSIGNED_COLOR);
+
+  return colorMap;
+};
+
+const buildGoalCalendarItems = (goals = [], topLevelById) => {
+  const resolved = topLevelById || resolveTopLevelGoalIds(goals);
+  return goals.map((goal) => ({
+    type: 'goal',
+    id: toGoalId(goal?._id),
+    title: goal?.title,
+    topLevelId: getTopLevelGoalId(goal?._id, resolved),
+    isTopLevel: !goal?.parentGoalId,
+    date: goal?.targetCompletionDate
+  }));
+};
+
+const buildTaskCalendarItems = (tasks = [], topLevelById) => {
+  const resolved = topLevelById || new Map();
+  return tasks.map((task) => ({
+    type: 'task',
+    id: toGoalId(task?._id),
+    title: task?.title,
+    topLevelId: task?.parentGoalId
+      ? getTopLevelGoalId(task.parentGoalId, resolved)
+      : UNASSIGNED_ID,
+    isTopLevel: false,
+    date: task?.targetCompletionDate
+  }));
+};
+
+// Resolves the label + pseudo flag for a top-level filter entry.
+const describeCalendarGroup = (id, goalsById) => {
+  if (id === UNASSIGNED_ID) {
+    return { id, title: 'Unassigned tasks', isPseudo: true };
+  }
+  return { id, title: goalsById.get(id)?.title || 'Unknown goal', isPseudo: false };
+};
+
+module.exports = {
+  UNASSIGNED_ID,
+  UNASSIGNED_COLOR,
+  CALENDAR_GOAL_COLORS,
+  buildGoalsById,
+  resolveTopLevelGoalIds,
+  getTopLevelGoalId,
+  buildGoalColorMap,
+  buildGoalCalendarItems,
+  buildTaskCalendarItems,
+  describeCalendarGroup
+};

--- a/packages/shared/src/calendarModel.test.js
+++ b/packages/shared/src/calendarModel.test.js
@@ -1,0 +1,98 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  UNASSIGNED_ID,
+  UNASSIGNED_COLOR,
+  CALENDAR_GOAL_COLORS,
+  resolveTopLevelGoalIds,
+  getTopLevelGoalId,
+  buildGoalColorMap,
+  buildGoalCalendarItems,
+  buildTaskCalendarItems,
+  describeCalendarGroup,
+  buildGoalsById
+} = require('./calendarModel');
+
+const goals = [
+  { _id: 'root-1', title: 'Launch Goal', parentGoalId: null, targetCompletionDate: '2026-01-14' },
+  { _id: 'child-1', title: 'Launch Subgoal', parentGoalId: 'root-1', targetCompletionDate: '2026-01-16' },
+  { _id: 'grand-1', title: 'Launch Deep', parentGoalId: 'child-1', targetCompletionDate: '2026-01-17' },
+  { _id: 'root-2', title: 'Health Goal', parentGoalId: null, targetCompletionDate: '2026-01-15' }
+];
+
+test('resolveTopLevelGoalIds walks up to the root goal', () => {
+  const map = resolveTopLevelGoalIds(goals);
+  assert.equal(map.get('root-1'), 'root-1');
+  assert.equal(map.get('child-1'), 'root-1');
+  assert.equal(map.get('grand-1'), 'root-1');
+  assert.equal(map.get('root-2'), 'root-2');
+});
+
+test('resolveTopLevelGoalIds tolerates cycles and missing parents', () => {
+  const cyclic = [
+    { _id: 'a', title: 'A', parentGoalId: 'b' },
+    { _id: 'b', title: 'B', parentGoalId: 'a' },
+    { _id: 'orphan', title: 'Orphan', parentGoalId: 'missing' }
+  ];
+  const map = resolveTopLevelGoalIds(cyclic);
+  // A goal in a cycle resolves to some stable id within the cycle.
+  assert.ok(['a', 'b'].includes(map.get('a')));
+  // A goal whose parent no longer exists resolves to that missing parent id
+  // (matches the web calendar's resolution), so it groups on its own.
+  assert.equal(map.get('orphan'), 'missing');
+});
+
+test('getTopLevelGoalId falls back to the id itself when unknown', () => {
+  const map = resolveTopLevelGoalIds(goals);
+  assert.equal(getTopLevelGoalId('grand-1', map), 'root-1');
+  assert.equal(getTopLevelGoalId('unknown', map), 'unknown');
+  assert.equal(getTopLevelGoalId(null, map), null);
+});
+
+test('buildGoalColorMap assigns deterministic colors ordered by title', () => {
+  const colorMap = buildGoalColorMap(goals);
+  // Two top-level trees: "Health Goal" sorts before "Launch Goal".
+  assert.equal(colorMap.get('root-2'), CALENDAR_GOAL_COLORS[0]);
+  assert.equal(colorMap.get('root-1'), CALENDAR_GOAL_COLORS[1]);
+  // Children inherit their tree color via the top-level id (not stored per-child).
+  assert.equal(colorMap.has('child-1'), false);
+  assert.equal(colorMap.get(UNASSIGNED_ID), UNASSIGNED_COLOR);
+});
+
+test('buildGoalCalendarItems marks top-level goals and resolves tree', () => {
+  const map = resolveTopLevelGoalIds(goals);
+  const items = buildGoalCalendarItems(goals, map);
+  const child = items.find((i) => i.id === 'child-1');
+  assert.equal(child.type, 'goal');
+  assert.equal(child.isTopLevel, false);
+  assert.equal(child.topLevelId, 'root-1');
+  const root = items.find((i) => i.id === 'root-1');
+  assert.equal(root.isTopLevel, true);
+});
+
+test('buildTaskCalendarItems groups by top-level goal, else unassigned', () => {
+  const map = resolveTopLevelGoalIds(goals);
+  const tasks = [
+    { _id: 't1', title: 'Linked Task', parentGoalId: 'child-1', targetCompletionDate: '2026-01-13' },
+    { _id: 't2', title: 'Free Task', parentGoalId: null, targetCompletionDate: '2026-01-18' }
+  ];
+  const items = buildTaskCalendarItems(tasks, map);
+  assert.equal(items.find((i) => i.id === 't1').topLevelId, 'root-1');
+  assert.equal(items.find((i) => i.id === 't2').topLevelId, UNASSIGNED_ID);
+  assert.equal(items.every((i) => i.type === 'task'), true);
+});
+
+test('describeCalendarGroup labels goals and the unassigned pseudo-group', () => {
+  const goalsById = buildGoalsById(goals);
+  assert.deepEqual(describeCalendarGroup('root-1', goalsById), {
+    id: 'root-1',
+    title: 'Launch Goal',
+    isPseudo: false
+  });
+  assert.deepEqual(describeCalendarGroup(UNASSIGNED_ID, goalsById), {
+    id: UNASSIGNED_ID,
+    title: 'Unassigned tasks',
+    isPseudo: true
+  });
+});

--- a/packages/shared/src/index.js
+++ b/packages/shared/src/index.js
@@ -3,6 +3,7 @@ const { createServices, buildAnalyticsQuery } = require('./services');
 const validation = require('./validation');
 const authUtils = require('./authUtils');
 const goalHierarchy = require('./goalHierarchy');
+const calendarModel = require('./calendarModel');
 
 module.exports = {
   createApiClient,
@@ -10,5 +11,6 @@ module.exports = {
   buildAnalyticsQuery,
   ...validation,
   ...authUtils,
-  ...goalHierarchy
+  ...goalHierarchy,
+  ...calendarModel
 };

--- a/src/pages/CalendarView.js
+++ b/src/pages/CalendarView.js
@@ -17,32 +17,20 @@ import {
   Typography
 } from "@mui/material";
 import { alpha } from "@mui/material/styles";
+import {
+  UNASSIGNED_ID,
+  resolveTopLevelGoalIds,
+  buildGoalColorMap,
+  buildGoalCalendarItems,
+  buildTaskCalendarItems,
+  describeCalendarGroup
+} from "@productivity/shared";
 import { fetchGoals } from "../features/goals/goalService";
 import { fetchTasks } from "../features/tasks/taskService";
 
 dayjs.extend(isBetween);
 
-const UNASSIGNED_ID = "unassigned";
-const baseColors = [
-  "#1d4ed8",
-  "#059669",
-  "#ea580c",
-  "#e11d48",
-  "#0f766e",
-  "#0ea5e9",
-  "#84cc16",
-  "#16a34a",
-  "#f59e0b",
-  "#dc2626"
-];
-
 const formatDayKey = (value) => dayjs(value).format("YYYY-MM-DD");
-
-const getTopLevelId = (goalId, topLevelByGoalId) => {
-  if (!goalId) return null;
-  const id = String(goalId);
-  return topLevelByGoalId.get(id) || id;
-};
 
 const CalendarView = () => {
   const [goals, setGoals] = useState([]);
@@ -117,64 +105,12 @@ const CalendarView = () => {
     return map;
   }, [goals]);
 
-  const topLevelByGoalId = useMemo(() => {
-    const map = new Map();
+  const topLevelByGoalId = useMemo(() => resolveTopLevelGoalIds(goals), [goals]);
 
-    const resolveTopLevel = (goalId, trail) => {
-      if (!goalId) return null;
-      const id = String(goalId);
-      if (map.has(id)) {
-        return map.get(id);
-      }
-      if (trail.has(id)) {
-        map.set(id, id);
-        return id;
-      }
-      const goal = goalsById.get(id);
-      if (!goal) {
-        map.set(id, id);
-        return id;
-      }
-      if (!goal.parentGoalId) {
-        map.set(id, id);
-        return id;
-      }
-      trail.add(id);
-      const parentId = String(goal.parentGoalId);
-      const rootId = resolveTopLevel(parentId, trail);
-      map.set(id, rootId || id);
-      return map.get(id);
-    };
-
-    goalsById.forEach((_goal, id) => {
-      resolveTopLevel(id, new Set());
-    });
-
-    return map;
-  }, [goalsById]);
-
-  const topLevelIds = useMemo(() => {
-    const ids = new Set();
-    goalsById.forEach((_goal, id) => {
-      ids.add(getTopLevelId(id, topLevelByGoalId) || id);
-    });
-    return Array.from(ids);
-  }, [goalsById, topLevelByGoalId]);
-
-  const goalColorMap = useMemo(() => {
-    const sortedGoals = topLevelIds
-      .map((id) => ({
-        id,
-        title: goalsById.get(id)?.title || "Unknown goal"
-      }))
-      .sort((a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: "base" }));
-    const map = new Map();
-    sortedGoals.forEach((goal, index) => {
-      map.set(goal.id, baseColors[index % baseColors.length]);
-    });
-    map.set(UNASSIGNED_ID, "#64748b");
-    return map;
-  }, [goalsById, topLevelIds]);
+  const goalColorMap = useMemo(
+    () => buildGoalColorMap(goals, topLevelByGoalId),
+    [goals, topLevelByGoalId]
+  );
 
   const goalsInRange = useMemo(
     () =>
@@ -197,29 +133,12 @@ const CalendarView = () => {
   );
 
   const goalItemsInRange = useMemo(
-    () =>
-      goalsInRange.map((goal) => ({
-        type: "goal",
-        id: String(goal._id),
-        title: goal.title,
-        topLevelId: getTopLevelId(goal._id, topLevelByGoalId),
-        isTopLevel: !goal.parentGoalId,
-        date: goal.targetCompletionDate
-      })),
+    () => buildGoalCalendarItems(goalsInRange, topLevelByGoalId),
     [goalsInRange, topLevelByGoalId]
   );
 
   const taskItemsInRange = useMemo(
-    () =>
-      tasksInRange.map((task) => ({
-        type: "task",
-        id: String(task._id),
-        title: task.title,
-        topLevelId: task.parentGoalId
-          ? getTopLevelId(task.parentGoalId, topLevelByGoalId)
-          : UNASSIGNED_ID,
-        date: task.targetCompletionDate
-      })),
+    () => buildTaskCalendarItems(tasksInRange, topLevelByGoalId),
     [tasksInRange, topLevelByGoalId]
   );
 
@@ -244,13 +163,7 @@ const CalendarView = () => {
 
   const availableGoals = useMemo(() => {
     const items = availableGoalIds
-      .map((id) => {
-        if (id === UNASSIGNED_ID) {
-          return { id, title: "Unassigned tasks", isPseudo: true };
-        }
-        const goal = goalsById.get(id);
-        return { id, title: goal?.title || "Unknown goal" };
-      })
+      .map((id) => describeCalendarGroup(id, goalsById))
       .sort((a, b) => {
         if (a.isPseudo) return 1;
         if (b.isPseudo) return -1;


### PR DESCRIPTION
## Summary
Phase 4 of the mobile parity build: the mobile **Calendar** tab (previously a "coming soon" placeholder) now mirrors the web `CalendarView` — goals and tasks laid out by deadline, with week/month range navigation, goal/task visibility toggles, and per-goal-tree color filters.

Instead of the web's tiny 7-column grid, mobile uses a scrollable **agenda** (`SectionList`) grouped by day (today marked), which fits a phone screen while keeping the same data model and filtering behavior. Tapping an item pushes `GoalDetail` / `TaskDetail`.

**Shared: calendar model extracted into `packages/shared`.** The web calendar's pure logic (resolving each goal to its top-level tree, assigning stable per-tree colors, building goal/task calendar items, and labeling the "Unassigned tasks" pseudo-group) moved into `calendarModel.js`, and web's `CalendarView` was refactored to consume it — no behavior change (its tests still pass). Both platforms now share this logic:

```js
// packages/shared/src/calendarModel.js
const topLevelById = resolveTopLevelGoalIds(goals); // handles missing parents + cycles
const colorMap = buildGoalColorMap(goals, topLevelById); // deterministic, ordered by title
const goalItems = buildGoalCalendarItems(goalsInRange, topLevelById);
const taskItems = buildTaskCalendarItems(tasksInRange, topLevelById); // no parent -> UNASSIGNED_ID
```

The mobile screen keeps the dayjs-based range windowing + day bucketing local (UI-specific); only the framework-agnostic pieces are shared.

## Testing
- `npm run test:shared` — added `calendarModel.test.js` (top-level resolution incl. cycles/missing parents, deterministic colors, item building, group labels); 66 shared tests pass.
- `mobile` `npm test` — added `CalendarScreen.test.js` (renders due items for the week, Tasks toggle hides tasks, goal-tree chip filters, tap → detail navigation); 24 mobile tests pass.
- Web `CalendarView` + goals suites still green (30 tests) — confirms the shared refactor is behavior-preserving.
- Web production build compiles clean (lint).
- Manual: validated on the Android emulator against the live backend (see below).

## Screenshots
Validated on the Android emulator against the live backend (goals + tasks seeded with deadlines this week):

| Week agenda (goal-tree color filters, today marked) | Month range |
| --- | --- |
| ![week](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMzRmNmJkM2EzNTZmNGI5ODgxZGUxNzZlZjE0N2E3ODQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMzRmNmJkM2EzNTZmNGI5ODgxZGUxNzZlZjE0N2E3ODQvYmI1MTk2YjItMDM5NC00ZjVhLWE1NTktZjY0OWJiMTNhN2Q2IiwiaWF0IjoxNzgzNDkyMjA2LCJleHAiOjE3ODQwOTcwMDYsImZpbGVuYW1lIjoiY2FsX3dlZWsucG5nIn0.FJpUUkJ0UbYA5CWwfCR-auK2xajVBb0Q5p_RekqNexw) | ![month](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMzRmNmJkM2EzNTZmNGI5ODgxZGUxNzZlZjE0N2E3ODQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMzRmNmJkM2EzNTZmNGI5ODgxZGUxNzZlZjE0N2E3ODQvZWNiNDlmYWQtMmUxNC00NzEyLTg1YTUtNTFlOGM5ZjdmMzk5IiwiaWF0IjoxNzgzNDkyMjA2LCJleHAiOjE3ODQwOTcwMDYsImZpbGVuYW1lIjoiY2FsX21vbnRoLnBuZyJ9.gtlKcWwOHvfZ4IJrinTpVd5N7C8Ua59PBjTw4A7Z9nE) |

## Recording
Full flow (toggle a goal-tree filter → scroll agenda → switch to Month → navigate ranges → tap an item), 2× speed:

![calendar demo](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMzRmNmJkM2EzNTZmNGI5ODgxZGUxNzZlZjE0N2E3ODQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMzRmNmJkM2EzNTZmNGI5ODgxZGUxNzZlZjE0N2E3ODQvZjFiOGJmNTItZmJlZS00YzVkLWJjMGItNzBkNWJkOGY2MTA5IiwiaWF0IjoxNzgzNDkyMjA3LCJleHAiOjE3ODQwOTcwMDcsImZpbGVuYW1lIjoiY2FsX2RlbW8uZ2lmIn0.8yF44a02qVHIj01AjVRDYpjKq65zKB8bgQZbfwnfIXI)

Link to Devin session: https://outpostai.devinenterprise.com/sessions/ff64e9512115425a99f6f54925e0d377
Requested by: @ysingh97