### PR TITLE
Add mobile E2E (Maestro) with CI workflow

### DIFF
--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -88,7 +88,21 @@ jobs:
           echo "backend failed to start"; cat "$GITHUB_WORKSPACE/backend.log"; exit 1
 
       - name: Prebuild Android project
-        run: npm --prefix mobile exec -- expo prebuild --platform android --no-install
+        run: |
+          cd mobile
+          npx expo prebuild --platform android --no-install
+
+      # The E2E backend is served over plain HTTP on the emulator host
+      # (10.0.2.2). Android blocks cleartext in release builds by default, so
+      # enable it for this throwaway test APK only (production is built via EAS,
+      # not this workflow, and is unaffected).
+      - name: Allow cleartext traffic for the test build
+        run: |
+          manifest=mobile/android/app/src/main/AndroidManifest.xml
+          if ! grep -q 'android:usesCleartextTraffic' "$manifest"; then
+            sed -i 's/<application android:name=".MainApplication"/<application android:name=".MainApplication" android:usesCleartextTraffic="true"/' "$manifest"
+          fi
+          grep -o 'android:usesCleartextTraffic="true"' "$manifest"
 
       - name: Build release APK (debug-signed, self-contained)
         run: |

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -4,6 +4,10 @@ name: Mobile E2E
 # against a real Android emulator and a live backend. This is heavier and slower
 # than the unit suites (it boots an emulator and builds the app), so it only runs
 # for changes that touch the mobile app / shared package, plus on-demand.
+#
+# NOTE: this repo's Actions policy only permits GitHub-owned (actions/*) actions,
+# so the emulator is provisioned with the runner's preinstalled Android SDK via
+# shell rather than a third-party setup action.
 on:
   workflow_dispatch:
   pull_request:
@@ -29,6 +33,7 @@ jobs:
       EXPO_PUBLIC_API_URL: http://10.0.2.2:5000/api
       EXPO_PUBLIC_ALLOW_DEV_SIGN_IN: 'true'
       EXPO_PUBLIC_DEV_AUTH_TOKEN: 'test:power'
+      ANDROID_IMAGE: system-images;android-34;google_apis;x86_64
     services:
       mongo:
         image: mongo:7
@@ -103,26 +108,38 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: Run Maestro E2E on emulator
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 34
-          target: google_apis
-          arch: x86_64
-          profile: pixel_6
-          disable-animations: true
-          script: |
-            adb install -r mobile/android/app/build/outputs/apk/release/app-release.apk
-            maestro test mobile/e2e/flows
+      - name: Install Android emulator image
+        run: |
+          yes | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" \
+            "platform-tools" "emulator" "platforms;android-34" "$ANDROID_IMAGE" > /dev/null
+          yes | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --licenses > /dev/null || true
 
-      - name: Upload Maestro artifacts
+      - name: Create and boot emulator
+        run: |
+          echo "no" | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/avdmanager" \
+            create avd -n ci -k "$ANDROID_IMAGE" -d pixel_6 --force
+          "$ANDROID_SDK_ROOT/emulator/emulator" -avd ci \
+            -no-window -no-audio -no-boot-anim -no-snapshot -gpu swiftshader_indirect \
+            > "$GITHUB_WORKSPACE/emulator.log" 2>&1 &
+          adb wait-for-device
+          timeout 300 bash -c 'while [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d "\r")" != "1" ]; do sleep 3; done'
+          adb shell input keyevent 82 || true
+          adb devices
+
+      - name: Run Maestro E2E
+        run: |
+          adb install -r mobile/android/app/build/outputs/apk/release/app-release.apk
+          maestro test mobile/e2e/flows
+
+      - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: maestro-artifacts
+          name: mobile-e2e-artifacts
           path: |
             ~/.maestro/tests
             backend.log
+            emulator.log
           if-no-files-found: ignore
           retention-days: 7
 
@@ -134,5 +151,5 @@ jobs:
             echo ""
             echo "- Provisioned an ephemeral MongoDB service (\`$MONGO_URI\`) and started the backend."
             echo "- Built a self-contained release APK via \`expo prebuild\` + \`gradlew assembleRelease\`."
-            echo "- Booted an Android 34 emulator and ran the Maestro flows in \`mobile/e2e/flows\`."
+            echo "- Booted an Android 34 emulator (runner SDK) and ran the Maestro flows in \`mobile/e2e/flows\`."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -134,12 +134,25 @@ jobs:
 
       - name: Create and boot emulator
         run: |
+          if [ -e /dev/kvm ]; then echo "KVM present"; else echo "WARNING: /dev/kvm missing"; fi
           echo "no" | avdmanager create avd -n ci -k "$ANDROID_IMAGE" -d pixel_6 --force
-          emulator -avd ci \
-            -no-window -no-audio -no-boot-anim -no-snapshot -gpu swiftshader_indirect \
+          nohup emulator -avd ci \
+            -no-window -no-audio -no-boot-anim -no-snapshot -accel on \
+            -gpu swiftshader_indirect -camera-back none -camera-front none -no-metrics \
             > "$GITHUB_WORKSPACE/emulator.log" 2>&1 &
-          adb wait-for-device
-          timeout 300 bash -c 'while [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d "\r")" != "1" ]; do sleep 3; done'
+          # Wait for the device to register; dump the emulator log if it never does.
+          if ! timeout 180 adb wait-for-device; then
+            echo "::error::emulator never registered a device"
+            cat "$GITHUB_WORKSPACE/emulator.log" || true
+            exit 1
+          fi
+          # Wait for full boot.
+          if ! timeout 300 bash -c 'while [ "$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d "\r")" != "1" ]; do sleep 3; done'; then
+            echo "::error::boot did not complete in time"
+            adb devices || true
+            cat "$GITHUB_WORKSPACE/emulator.log" || true
+            exit 1
+          fi
           adb shell input keyevent 82 || true
           adb devices
 

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -1,0 +1,138 @@
+name: Mobile E2E
+
+# Device-level end-to-end tests for the Branchwork mobile app, driven by Maestro
+# against a real Android emulator and a live backend. This is heavier and slower
+# than the unit suites (it boots an emulator and builds the app), so it only runs
+# for changes that touch the mobile app / shared package, plus on-demand.
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'mobile/**'
+      - 'packages/shared/**'
+      - '.github/workflows/mobile-e2e.yml'
+
+# Avoid piling up emulator runs on rapid pushes.
+concurrency:
+  group: mobile-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mobile-e2e:
+    name: Mobile E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      MONGO_URI: mongodb://127.0.0.1:27017/branchwork_mobile_e2e
+      # Baked into the release bundle at build time; the emulator reaches the
+      # runner host (where the backend listens) via 10.0.2.2.
+      EXPO_PUBLIC_API_URL: http://10.0.2.2:5000/api
+      EXPO_PUBLIC_ALLOW_DEV_SIGN_IN: 'true'
+      EXPO_PUBLIC_DEV_AUTH_TOKEN: 'test:power'
+    services:
+      mongo:
+        image: mongo:7
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --eval \"db.adminCommand({ ping: 1 })\""
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            app-server/package-lock.json
+            mobile/package-lock.json
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Install workspace dependencies
+        run: npm ci
+
+      - name: Install backend dependencies
+        run: npm --prefix app-server ci
+
+      - name: Install mobile dependencies
+        run: npm --prefix mobile ci
+
+      - name: Start backend
+        run: |
+          cd app-server
+          NODE_ENV=development ALLOW_TEST_AUTH=true PORT=5000 \
+            MONGO_URI="$MONGO_URI" nohup npm start > "$GITHUB_WORKSPACE/backend.log" 2>&1 &
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:5000/api/health > /dev/null; then
+              echo "backend is up"; exit 0
+            fi
+            sleep 2
+          done
+          echo "backend failed to start"; cat "$GITHUB_WORKSPACE/backend.log"; exit 1
+
+      - name: Prebuild Android project
+        run: npm --prefix mobile exec -- expo prebuild --platform android --no-install
+
+      - name: Build release APK (debug-signed, self-contained)
+        run: |
+          cd mobile/android
+          ./gradlew :app:assembleRelease --no-daemon
+
+      - name: Install Maestro
+        run: |
+          export MAESTRO_VERSION=1.39.0
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run Maestro E2E on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          disable-animations: true
+          script: |
+            adb install -r mobile/android/app/build/outputs/apk/release/app-release.apk
+            maestro test mobile/e2e/flows
+
+      - name: Upload Maestro artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-artifacts
+          path: |
+            ~/.maestro/tests
+            backend.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Write summary
+        if: always()
+        run: |
+          {
+            echo "## Mobile E2E"
+            echo ""
+            echo "- Provisioned an ephemeral MongoDB service (\`$MONGO_URI\`) and started the backend."
+            echo "- Built a self-contained release APK via \`expo prebuild\` + \`gradlew assembleRelease\`."
+            echo "- Booted an Android 34 emulator and ran the Maestro flows in \`mobile/e2e/flows\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -127,12 +127,15 @@ jobs:
           yes | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" \
             "platform-tools" "emulator" "platforms;android-34" "$ANDROID_IMAGE" > /dev/null
           yes | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --licenses > /dev/null || true
+          # Put adb / emulator / avdmanager on PATH for subsequent steps.
+          echo "$ANDROID_SDK_ROOT/platform-tools" >> "$GITHUB_PATH"
+          echo "$ANDROID_SDK_ROOT/emulator" >> "$GITHUB_PATH"
+          echo "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin" >> "$GITHUB_PATH"
 
       - name: Create and boot emulator
         run: |
-          echo "no" | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/avdmanager" \
-            create avd -n ci -k "$ANDROID_IMAGE" -d pixel_6 --force
-          "$ANDROID_SDK_ROOT/emulator/emulator" -avd ci \
+          echo "no" | avdmanager create avd -n ci -k "$ANDROID_IMAGE" -d pixel_6 --force
+          emulator -avd ci \
             -no-window -no-audio -no-boot-anim -no-snapshot -gpu swiftshader_indirect \
             > "$GITHUB_WORKSPACE/emulator.log" 2>&1 &
           adb wait-for-device

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -133,9 +133,18 @@ jobs:
           echo "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin" >> "$GITHUB_PATH"
 
       - name: Create and boot emulator
+        env:
+          # Pin a single AVD home so avdmanager (create) and emulator (launch)
+          # agree on where the AVD lives.
+          ANDROID_AVD_HOME: /home/runner/.android/avd
         run: |
           if [ -e /dev/kvm ]; then echo "KVM present"; else echo "WARNING: /dev/kvm missing"; fi
-          echo "no" | avdmanager create avd -n ci -k "$ANDROID_IMAGE" -d pixel_6 --force
+          mkdir -p "$ANDROID_AVD_HOME"
+          echo "no" | avdmanager create avd -n ci -k "$ANDROID_IMAGE" --force
+          echo "Available AVDs:"; emulator -list-avds
+          if ! emulator -list-avds | grep -qx ci; then
+            echo "::error::AVD 'ci' was not created"; exit 1
+          fi
           nohup emulator -avd ci \
             -no-window -no-audio -no-boot-anim -no-snapshot -accel on \
             -gpu swiftshader_indirect -camera-back none -camera-front none -no-metrics \

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -47,9 +47,21 @@ npm start         # Expo dev server (choose a target)
   `Mobile Tests` CI job on every PR.
 - **End-to-end** (`npm run test:e2e`): [Maestro](https://maestro.mobile.dev) flows in
   `e2e/flows/` driving a real emulator against the live backend. Prereqs: a booted
-  Android emulator/device with the app installed, Metro (for a dev build) or a
-  self-contained release build, and the backend reachable at `EXPO_PUBLIC_API_URL`.
-  Install Maestro with `curl -Ls https://get.maestro.mobile.dev | bash`.
+  Android emulator/device with the app installed and the backend reachable at
+  `EXPO_PUBLIC_API_URL`. Install Maestro with `curl -Ls https://get.maestro.mobile.dev | bash`.
+
+  Quickest install for a run is a dev build (`npm run android`, keeps Metro up).
+  To mirror CI (self-contained release APK, no Metro):
+  ```
+  npx expo prebuild --platform android --no-install
+  # release builds block cleartext HTTP; the emulator backend is http://10.0.2.2 —
+  # enable it for this test-only APK (production is built via EAS, unaffected):
+  sed -i 's/<application android:name=".MainApplication"/&  android:usesCleartextTraffic="true"/' \
+    android/app/src/main/AndroidManifest.xml
+  (cd android && ./gradlew :app:assembleRelease)
+  adb install -r android/app/build/outputs/apk/release/app-release.apk
+  npm run test:e2e
+  ```
 
   Flows:
   - `smoke.yaml` — developer sign-in, then assert each primary tab (Board/Lists/Goals/Calendar) renders.

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -42,17 +42,36 @@ npm start         # Expo dev server (choose a target)
 > Native Google Sign-In / secure store require a development build (EAS Build) or
 > Expo Go depending on the module. Developer sign-in works without Google OAuth.
 
+## Tests
+- **Unit / component** (`npm test`): Jest + React Native Testing Library. Runs in the
+  `Mobile Tests` CI job on every PR.
+- **End-to-end** (`npm run test:e2e`): [Maestro](https://maestro.mobile.dev) flows in
+  `e2e/flows/` driving a real emulator against the live backend. Prereqs: a booted
+  Android emulator/device with the app installed, Metro (for a dev build) or a
+  self-contained release build, and the backend reachable at `EXPO_PUBLIC_API_URL`.
+  Install Maestro with `curl -Ls https://get.maestro.mobile.dev | bash`.
+
+  Flows:
+  - `smoke.yaml` — developer sign-in, then assert each primary tab (Board/Lists/Goals/Calendar) renders.
+  - `task-crud.yaml` — create a task via the form (round-trips to the backend), see it on the Board, open and delete it.
+
+  In CI the `Mobile E2E` workflow (`.github/workflows/mobile-e2e.yml`) builds a
+  debug-signed release APK, boots an Android 34 emulator, starts Mongo + backend,
+  and runs the flows. It only triggers on `mobile/**` / `packages/shared/**` changes
+  (and `workflow_dispatch`) because booting an emulator + building the app is slow.
+
 ## Structure
 ```
 mobile/
   App.js                     # providers (Paper theme, auth) + navigation root
   metro.config.js            # monorepo config to resolve @productivity/shared
+  e2e/                       # Maestro end-to-end flows
   src/
     api/                     # api client (SecureStore token) + services
     auth/                    # AuthContext (SecureStore-backed)
     config/env.js            # EXPO_PUBLIC_* config
     navigation/              # stack + bottom tabs
-    screens/                 # SignIn, Board, Lists, Goals, Settings, ...
+    screens/                 # SignIn, Board, Lists, Goals, Calendar, Settings, ...
     components/              # shared UI bits
     theme.js                 # Paper light/dark themes matching the web palette
 ```
@@ -60,4 +79,4 @@ mobile/
 ## Notes
 - `@productivity/shared` is consumed via a `file:` dependency and resolved by Metro
   (`metro.config.js`). Axios is aliased to its browser build for React Native.
-- Calendar and Visualizations screens are placeholders pending follow-up work.
+- The Visualizations/Analytics screen is a placeholder pending follow-up work.

--- a/mobile/e2e/config.yaml
+++ b/mobile/e2e/config.yaml
@@ -1,0 +1,5 @@
+# Maestro workspace config for the Branchwork mobile E2E suite.
+# Run with: npm run test:e2e  (from mobile/) — requires a booted Android
+# emulator/device with the app installed and the backend reachable.
+flows:
+  - flows/*.yaml

--- a/mobile/e2e/flows/smoke.yaml
+++ b/mobile/e2e/flows/smoke.yaml
@@ -1,0 +1,21 @@
+# Dev sign-in, then verify every primary tab renders its own screen.
+appId: com.branchwork.app
+tags:
+  - smoke
+---
+- launchApp:
+    clearState: true
+    permissions:
+      all: allow
+- tapOn: "Developer sign-in"
+# Board (default tab) is reached once its create FAB is present.
+- assertVisible: "Create task"
+- tapOn: "Lists"
+- assertVisible: "Create list"
+- tapOn: "Goals"
+- assertVisible: "Create goal"
+- tapOn: "Calendar"
+- assertVisible: "Week"
+- assertVisible: "Month"
+- tapOn: "Board"
+- assertVisible: "Create task"

--- a/mobile/e2e/flows/task-crud.yaml
+++ b/mobile/e2e/flows/task-crud.yaml
@@ -17,12 +17,20 @@ tags:
 - inputText: "E2E Maestro Task"
 - hideKeyboard
 # Submit button shares the "Create task" label; only the form is on screen here.
+# The form scrolls, so bring the submit button into view before tapping it.
+- scrollUntilVisible:
+    element:
+      text: "Create task"
+    direction: DOWN
 - tapOn: "Create task"
 # Back on the Board, the new task is listed.
 - assertVisible: "E2E Maestro Task"
 # Open it and delete it to clean up.
 - tapOn: "E2E Maestro Task"
-- assertVisible: "Delete task"
+- scrollUntilVisible:
+    element:
+      text: "Delete task"
+    direction: DOWN
 - tapOn: "Delete task"
 - assertVisible: "Delete task?"
 - tapOn: "Delete"

--- a/mobile/e2e/flows/task-crud.yaml
+++ b/mobile/e2e/flows/task-crud.yaml
@@ -1,0 +1,29 @@
+# Create a task through the form (round-trips to the live backend), confirm it
+# lands on the Board, then open it and delete it so the run is self-cleaning.
+appId: com.branchwork.app
+tags:
+  - crud
+---
+- launchApp:
+    clearState: true
+    permissions:
+      all: allow
+- tapOn: "Developer sign-in"
+- assertVisible: "Create task"
+# Open the create-task form via the Board FAB.
+- tapOn: "Create task"
+- assertVisible: "New task"
+- tapOn: "Title"
+- inputText: "E2E Maestro Task"
+- hideKeyboard
+# Submit button shares the "Create task" label; only the form is on screen here.
+- tapOn: "Create task"
+# Back on the Board, the new task is listed.
+- assertVisible: "E2E Maestro Task"
+# Open it and delete it to clean up.
+- tapOn: "E2E Maestro Task"
+- assertVisible: "Delete task"
+- tapOn: "Delete task"
+- assertVisible: "Delete task?"
+- tapOn: "Delete"
+- assertNotVisible: "E2E Maestro Task"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -8,7 +8,8 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "maestro test e2e/flows"
   },
   "jest": {
     "preset": "jest-expo",


### PR DESCRIPTION
## Summary
Adds device-level end-to-end testing for the Branchwork mobile app — closing the gap I'd flagged (mobile coverage was component/logic-level only; the E2E CI job was web/Playwright). Uses **Maestro** (YAML flows on a real Android emulator), driving the app against a live backend.

Two flows in `mobile/e2e/flows/`:
- `smoke.yaml` — developer sign-in, then assert every primary tab renders its own screen (Board/Lists/Goals/Calendar), anchored on per-screen elements (create FABs, the Calendar Week/Month toggle).
- `task-crud.yaml` — create a task through the form (round-trips to the backend), confirm it appears on the Board, open it, and delete it (self-cleaning).

Run locally with `npm run test:e2e` (from `mobile/`); requires a booted emulator with the app installed + the backend reachable at `EXPO_PUBLIC_API_URL`.

## CI (`.github/workflows/mobile-e2e.yml`)
Provisions Mongo + backend, builds a self-contained APK, boots an emulator, and runs the flows:
```
expo prebuild --platform android            # generate native project (run inside mobile/)
# release builds block cleartext HTTP; the emulator backend is http://10.0.2.2 —
# enable it on this throwaway test APK only (prod is built via EAS, unaffected)
gradlew :app:assembleRelease                # debug-signed, JS bundled -> no Metro at runtime
sdkmanager/avdmanager/emulator (runner SDK) # api-34 google_apis x86_64, booted via shell
adb install -r .../app-release.apk
maestro test mobile/e2e/flows
```
**Note:** this repo's Actions policy only permits GitHub-owned (`actions/*`) actions, so the emulator is provisioned with the runner's preinstalled Android SDK via shell rather than a third-party setup action. Key gotchas handled along the way: put `platform-tools`/`emulator` on `PATH`, pin `ANDROID_AVD_HOME` so `avdmanager` and `emulator` agree on the AVD location, and `scrollUntilVisible` before tapping the form's submit/delete buttons (the taller CI emulator pushes them below the fold).

The app reaches the runner-hosted backend via `10.0.2.2:5000` (baked into the bundle through `EXPO_PUBLIC_API_URL` at build time); auth uses the existing dev sign-in test persona (`test:power`), so no Google OAuth is needed.

Deliberately **scoped and non-blocking**: it only triggers on `mobile/**` / `packages/shared/**` changes (and `workflow_dispatch`), and is a separate workflow — booting an emulator + building the app is ~15-20 min and inherently more flaky than unit tests, so it isn't a required check unless you make it one in branch protection.

No app source changed — only new test/CI/doc files.

## Testing
Both flows pass in CI (Mobile E2E job green) and locally on the Android emulator against the live backend:
```
[Passed] smoke (22s)
[Passed] task-crud (34s)
2/2 Flows Passed
```
All 8 PR checks green (Frontend/Backend/Shared/Mobile builds + tests, web E2E, Mobile E2E).

## Recording
`task-crud` flow running on the emulator (create → appears on Board → open → delete), 2× speed:

![mobile e2e demo](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMzRmNmJkM2EzNTZmNGI5ODgxZGUxNzZlZjE0N2E3ODQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMzRmNmJkM2EzNTZmNGI5ODgxZGUxNzZlZjE0N2E3ODQvNWQyYmQzMDctODEwNi00OGEyLWFiMTYtYzlkZGZkNGQ2NmU0IiwiaWF0IjoxNzgzNDkzMzg0LCJleHAiOjE3ODQwOTgxODQsImZpbGVuYW1lIjoiZTJlX2RlbW8uZ2lmIn0.anyITQ0EI5fHIjiltR7UmLQOSxhaGFFHvv0h3pIB4Cs)

Link to Devin session: https://outpostai.devinenterprise.com/sessions/ff64e9512115425a99f6f54925e0d377
Requested by: @ysingh97