### PR TITLE
Mobile E2E: add Lists, Goals, and Calendar Maestro flows

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -66,6 +66,9 @@ npm start         # Expo dev server (choose a target)
   Flows:
   - `smoke.yaml` — developer sign-in, then assert each primary tab (Board/Lists/Goals/Calendar) renders.
   - `task-crud.yaml` — create a task via the form (round-trips to the backend), see it on the Board, open and delete it.
+  - `lists.yaml` — create a list, see it on the Lists tab, open its detail (no delete endpoint, so no cleanup).
+  - `goals.yaml` — create a goal, see it on the Goals tab, open and delete it.
+  - `calendar.yaml` — exercise Calendar range nav (Prev/Today/Next), the Week/Month switch, and the Tasks toggle.
   - `visualizations.yaml` — open the Analytics tab and assert the stat cards + period controls render across Week/Year.
 
   In CI the `Mobile E2E` workflow (`.github/workflows/mobile-e2e.yml`) builds a

--- a/mobile/e2e/flows/calendar.yaml
+++ b/mobile/e2e/flows/calendar.yaml
@@ -1,0 +1,28 @@
+# Exercise the Calendar tab: range navigation (Prev/Today/Next), the Week/Month
+# range switch, and the Tasks visibility toggle. Read-only, so no cleanup needed.
+# The Tasks checkbox is used for the toggle (the "Goals" checkbox label collides
+# with the bottom "Goals" tab, so it is left alone here).
+appId: com.branchwork.app
+tags:
+  - smoke
+---
+- launchApp:
+    clearState: true
+    permissions:
+      all: allow
+- tapOn: "Developer sign-in"
+- assertVisible: "Create task"
+- tapOn: "Calendar"
+- assertVisible: "Week"
+- assertVisible: "Month"
+# Range navigation controls.
+- tapOn: "Prev"
+- tapOn: "Next"
+- tapOn: "Today"
+# Switch to the month range and back to week.
+- tapOn: "Month"
+- tapOn: "Week"
+# Toggle the Tasks filter off and back on; the calendar still renders.
+- tapOn: "Tasks"
+- tapOn: "Tasks"
+- assertVisible: "Week"

--- a/mobile/e2e/flows/goals.yaml
+++ b/mobile/e2e/flows/goals.yaml
@@ -1,0 +1,39 @@
+# Create a goal through the form (round-trips to the live backend), confirm it
+# lands on the Goals tab, then open it and delete it so the run is self-cleaning.
+appId: com.branchwork.app
+tags:
+  - crud
+---
+- launchApp:
+    clearState: true
+    permissions:
+      all: allow
+- tapOn: "Developer sign-in"
+- assertVisible: "Create task"
+- tapOn: "Goals"
+- assertVisible: "Create goal"
+# Open the create-goal form via the Goals FAB.
+- tapOn: "Create goal"
+- assertVisible: "New goal"
+- tapOn: "Title"
+- inputText: "E2E Maestro Goal"
+- hideKeyboard
+# Submit button shares the "Create goal" label; the form scrolls, so bring the
+# submit button into view before tapping it.
+- scrollUntilVisible:
+    element:
+      text: "Create goal"
+    direction: DOWN
+- tapOn: "Create goal"
+# Back on the Goals tab, the new goal is listed.
+- assertVisible: "E2E Maestro Goal"
+# Open it and delete it to clean up.
+- tapOn: "E2E Maestro Goal"
+- scrollUntilVisible:
+    element:
+      text: "Delete goal"
+    direction: DOWN
+- tapOn: "Delete goal"
+- assertVisible: "Delete goal?"
+- tapOn: "Delete"
+- assertNotVisible: "E2E Maestro Goal"

--- a/mobile/e2e/flows/lists.yaml
+++ b/mobile/e2e/flows/lists.yaml
@@ -1,0 +1,28 @@
+# Create a list through the form (round-trips to the live backend), confirm it
+# lands on the Lists tab, then open it to verify its detail screen. Lists have no
+# delete endpoint (web parity), so this flow does not clean up after itself.
+appId: com.branchwork.app
+tags:
+  - crud
+---
+- launchApp:
+    clearState: true
+    permissions:
+      all: allow
+- tapOn: "Developer sign-in"
+- assertVisible: "Create task"
+- tapOn: "Lists"
+- assertVisible: "Create list"
+# Open the create-list form via the Lists FAB.
+- tapOn: "Create list"
+- assertVisible: "New list"
+- tapOn: "Title"
+- inputText: "E2E Maestro List"
+- hideKeyboard
+# Submit button shares the "Create list" label; only the form is on screen here.
+- tapOn: "Create list"
+# Back on the Lists tab, the new list is listed.
+- assertVisible: "E2E Maestro List"
+# Open it and confirm the detail screen renders its add-task action.
+- tapOn: "E2E Maestro List"
+- assertVisible: "Add task to list"


### PR DESCRIPTION
## Summary

Extends the mobile Maestro E2E suite (added in #36, which only covered `smoke` + `task-crud`) to the remaining primary tabs. The `Mobile E2E` workflow already globs `flows/*.yaml`, so these run automatically with no workflow change.

New flows in `mobile/e2e/flows/`:
- **`lists.yaml`** — dev sign-in → Lists tab → create a list via the form (round-trips to the live backend) → assert it lands on the tab → open its detail. Lists have no delete endpoint (web parity), so this flow intentionally does not clean up.
- **`goals.yaml`** — dev sign-in → Goals tab → create a goal → assert it lands on the tab → open detail → delete (self-cleaning, mirrors `task-crud`).
- **`calendar.yaml`** — dev sign-in → Calendar tab → range nav (Prev/Next/Today), Week/Month switch, and the Tasks visibility toggle. Read-only, no cleanup. (Only the `Tasks` checkbox is toggled — the `Goals` checkbox label collides with the bottom `Goals` tab.)

README's E2E flow list updated to match.

## Tests
All three run green on the Android emulator against the live backend (release APK + Mongo + backend), same setup as CI:

```
Flow lists     ... 14 steps COMPLETED
Flow goals     ... create → detail → delete, 19 steps COMPLETED
Flow calendar  ... nav + Week/Month + Tasks toggle, 14 steps COMPLETED
```

### Recording — goals flow (create → view → delete)
![goals e2e](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMzRmNmJkM2EzNTZmNGI5ODgxZGUxNzZlZjE0N2E3ODQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMzRmNmJkM2EzNTZmNGI5ODgxZGUxNzZlZjE0N2E3ODQvMWI4M2E0NzAtMzQ5YS00NWY1LThlNGYtYTFiNmM3OTZkZmU2IiwiaWF0IjoxNzgzNTgyMTQ1LCJleHAiOjE3ODQxODY5NDUsImZpbGVuYW1lIjoiZ29hbHNfZTJlLndlYnAifQ.gLQEmCgR_HvHuqipnZ8oTvVLqj8djKPw-xRu1iCqjAY)

### Screenshots
| Lists (after create) | Calendar |
| --- | --- |
| ![lists](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMzRmNmJkM2EzNTZmNGI5ODgxZGUxNzZlZjE0N2E3ODQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMzRmNmJkM2EzNTZmNGI5ODgxZGUxNzZlZjE0N2E3ODQvNTJjNWFlNDUtNjZhMS00MzlhLTk4NjctYjFiNWRmYmQ3YjU3IiwiaWF0IjoxNzgzNTgyMTQ1LCJleHAiOjE3ODQxODY5NDUsImZpbGVuYW1lIjoiZTJlX2xpc3RzLnBuZyJ9.tVE3aD6-F7i0QUMT0um1GvtfATekODRrBECG3fx1irU) | ![calendar](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMzRmNmJkM2EzNTZmNGI5ODgxZGUxNzZlZjE0N2E3ODQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMzRmNmJkM2EzNTZmNGI5ODgxZGUxNzZlZjE0N2E3ODQvOTRmMDJmYjUtODI5MC00OTM0LWFkMjQtODJkNDFhNGU5YzYxIiwiaWF0IjoxNzgzNTgyMTQ1LCJleHAiOjE3ODQxODY5NDUsImZpbGVuYW1lIjoiZTJlX2NhbGVuZGFyLnBuZyJ9.NaANI401K9VDtO3nCneqiy4teMlgP0rhc6Z6vzlO4xw) |

## Notes
- No app/source changes — flows only exercise existing screens; nothing to rebuild for the app.
- Independent of #37 (analytics); both touch the README flow list, so a trivial merge may be needed depending on merge order — I'll resolve it.
- CI `Mobile E2E` is the relevant check; it now runs 5 flows (~a few min longer).

Link to Devin session: https://outpostai.devinenterprise.com/sessions/ff64e9512115425a99f6f54925e0d377
Requested by: @ysingh97