### PR TITLE
Add AI goal planner (OpenAI) with propose → review → save flow

### DIFF
--- a/app-server/.env.development.example
+++ b/app-server/.env.development.example
@@ -17,6 +17,11 @@ GOOGLE_CLIENT_SECRET=replace_with_google_oauth_client_secret
 # Android OAuth client IDs used by the mobile apps.
 GOOGLE_ALLOWED_AUDIENCES=
 
+# OpenAI API key for the AI goal planner (server-side only; never expose to clients)
+OPENAI_API_KEY=replace_with_openai_api_key
+# Optional: override the model used for planning (defaults to gpt-4o-mini)
+OPENAI_MODEL=gpt-4o-mini
+
 # Google Calendar OAuth settings for local development
 GOOGLE_CALENDAR_REDIRECT_URI=http://localhost:5000/api/integrations/google-calendar/callback
 APP_URL=http://localhost:3000

--- a/app-server/.env.production.example
+++ b/app-server/.env.production.example
@@ -17,6 +17,11 @@ GOOGLE_CLIENT_SECRET=replace_with_google_oauth_client_secret
 # Android OAuth client IDs used by the mobile apps.
 GOOGLE_ALLOWED_AUDIENCES=
 
+# OpenAI API key for the AI goal planner (server-side only; never expose to clients)
+OPENAI_API_KEY=replace_with_openai_api_key
+# Optional: override the model used for planning (defaults to gpt-4o-mini)
+OPENAI_MODEL=gpt-4o-mini
+
 # Google Calendar OAuth settings for production
 GOOGLE_CALENDAR_REDIRECT_URI=https://your-api-domain.com/api/integrations/google-calendar/callback
 APP_URL=https://your-frontend-domain.com

--- a/app-server/__tests__/aiRoutes.test.js
+++ b/app-server/__tests__/aiRoutes.test.js
@@ -1,0 +1,141 @@
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const request = require('supertest');
+
+jest.mock('../services/openaiService', () => ({
+  generatePlan: jest.fn()
+}));
+
+const openaiService = require('../services/openaiService');
+const createApp = require('../app');
+const Category = require('../models/category');
+const Goal = require('../models/goal');
+const User = require('../models/user');
+const { testAuthUsers } = require('../utils/testAuth');
+
+jest.setTimeout(60000);
+
+const originalAllowTestAuth = process.env.ALLOW_TEST_AUTH;
+
+let app;
+let mongoServer;
+
+const createTestUser = async (persona) => {
+  const payload = testAuthUsers[persona];
+  return User.create({
+    googleId: payload.sub,
+    email: payload.email,
+    name: payload.name,
+    picture: payload.picture
+  });
+};
+
+const samplePlan = {
+  goal: {
+    title: 'Learn Spanish',
+    description: 'Reach conversational level.',
+    category: 'Learning',
+    estimatedHours: 40,
+    suggestedTargetDate: null,
+    subGoals: [],
+    tasks: []
+  }
+};
+
+beforeAll(async () => {
+  process.env.ALLOW_TEST_AUTH = 'true';
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+  app = createApp();
+});
+
+afterEach(async () => {
+  await Goal.deleteMany({});
+  await Category.deleteMany({});
+  await User.deleteMany({});
+  jest.clearAllMocks();
+});
+
+afterAll(async () => {
+  if (originalAllowTestAuth === undefined) {
+    delete process.env.ALLOW_TEST_AUTH;
+  } else {
+    process.env.ALLOW_TEST_AUTH = originalAllowTestAuth;
+  }
+
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+test('ai plan route requires authentication', async () => {
+  await request(app)
+    .post('/api/ai/plan')
+    .send({ prompt: 'anything' })
+    .expect(401)
+    .expect({ message: 'Missing auth token' });
+});
+
+test('ai plan route rejects an empty prompt', async () => {
+  await createTestUser('basic');
+
+  await request(app)
+    .post('/api/ai/plan')
+    .set('Authorization', 'Bearer test:basic')
+    .send({ prompt: '   ' })
+    .expect(400)
+    .expect({ message: 'A prompt describing your goal is required' });
+
+  expect(openaiService.generatePlan).not.toHaveBeenCalled();
+});
+
+test('ai plan route returns the generated plan and passes user context', async () => {
+  const user = await createTestUser('basic');
+  await Category.create([
+    { title: 'Learning', userId: user._id },
+    { title: 'Fitness', userId: user._id }
+  ]);
+  await Goal.create({ title: 'Existing goal', userId: user._id });
+
+  openaiService.generatePlan.mockResolvedValue(samplePlan);
+
+  await request(app)
+    .post('/api/ai/plan')
+    .set('Authorization', 'Bearer test:basic')
+    .send({ prompt: 'I want to learn Spanish' })
+    .expect(200)
+    .expect(({ body }) => {
+      expect(body.plan.goal.title).toBe('Learn Spanish');
+    });
+
+  expect(openaiService.generatePlan).toHaveBeenCalledTimes(1);
+  const args = openaiService.generatePlan.mock.calls[0][0];
+  expect(args.prompt).toBe('I want to learn Spanish');
+  expect(args.categories).toEqual(['Fitness', 'Learning']);
+  expect(args.existingGoalTitles).toEqual(['Existing goal']);
+});
+
+test('ai plan route returns 503 when the key is not configured', async () => {
+  await createTestUser('basic');
+  const error = new Error('OPENAI_API_KEY is not configured');
+  error.code = 'OPENAI_NOT_CONFIGURED';
+  openaiService.generatePlan.mockRejectedValue(error);
+
+  await request(app)
+    .post('/api/ai/plan')
+    .set('Authorization', 'Bearer test:basic')
+    .send({ prompt: 'plan something' })
+    .expect(503)
+    .expect({ message: 'AI planning is not configured on the server.' });
+});
+
+test('ai plan route returns 502 on unexpected service failures', async () => {
+  await createTestUser('basic');
+  openaiService.generatePlan.mockRejectedValue(new Error('network exploded'));
+
+  await request(app)
+    .post('/api/ai/plan')
+    .set('Authorization', 'Bearer test:basic')
+    .send({ prompt: 'plan something' })
+    .expect(502)
+    .expect({ message: 'Unable to generate a plan right now. Please try again.' });
+});

--- a/app-server/__tests__/openaiService.test.js
+++ b/app-server/__tests__/openaiService.test.js
@@ -1,0 +1,137 @@
+const openaiService = require('../services/openaiService');
+
+const makeClient = (content, onCreate) => ({
+  chat: {
+    completions: {
+      create: async (params) => {
+        if (onCreate) onCreate(params);
+        return { choices: [{ message: { content } }] };
+      }
+    }
+  }
+});
+
+const validPlan = {
+  goal: {
+    title: 'Run a half marathon',
+    description: 'Train progressively over three months.',
+    category: 'Fitness',
+    estimatedHours: 60,
+    suggestedTargetDate: '2026-10-15',
+    subGoals: [
+      {
+        title: 'Build a base',
+        description: 'Establish a running routine.',
+        estimatedHours: 20,
+        suggestedTargetDate: '2026-08-15',
+        tasks: [
+          {
+            title: 'Run 3x per week',
+            description: '30 minute easy runs',
+            estimatedCompletionTime: 6,
+            suggestedTargetDate: null
+          }
+        ]
+      }
+    ],
+    tasks: [
+      {
+        title: 'Buy running shoes',
+        description: '',
+        estimatedCompletionTime: 1,
+        suggestedTargetDate: null
+      }
+    ]
+  }
+};
+
+test('generatePlan requires a non-empty prompt', async () => {
+  await expect(openaiService.generatePlan({ prompt: '   ' })).rejects.toMatchObject({
+    code: 'INVALID_PROMPT'
+  });
+});
+
+test('generatePlan returns a normalized plan from the model response', async () => {
+  const client = makeClient(JSON.stringify(validPlan));
+  const plan = await openaiService.generatePlan({
+    prompt: 'half marathon',
+    categories: ['Fitness'],
+    client
+  });
+
+  expect(plan.goal.title).toBe('Run a half marathon');
+  expect(plan.goal.estimatedHours).toBe(60);
+  expect(plan.goal.subGoals).toHaveLength(1);
+  expect(plan.goal.subGoals[0].tasks[0].title).toBe('Run 3x per week');
+  expect(plan.goal.tasks[0].title).toBe('Buy running shoes');
+});
+
+test('generatePlan passes structured-output config and context to the client', async () => {
+  let captured;
+  const client = makeClient(JSON.stringify(validPlan), (params) => {
+    captured = params;
+  });
+
+  await openaiService.generatePlan({
+    prompt: 'half marathon',
+    categories: ['Fitness', 'Health'],
+    existingGoalTitles: ['Learn guitar'],
+    today: '2026-07-16',
+    client
+  });
+
+  expect(captured.response_format.type).toBe('json_schema');
+  expect(captured.messages[0].role).toBe('system');
+  expect(captured.messages[0].content).toContain('Fitness');
+  expect(captured.messages[1].content).toContain('half marathon');
+  expect(captured.messages[1].content).toContain('Learn guitar');
+});
+
+test('generatePlan sanitizes invalid numbers, dates, and empty items', async () => {
+  const messyPlan = {
+    goal: {
+      title: '  Messy goal  ',
+      description: '',
+      category: '',
+      estimatedHours: -5,
+      suggestedTargetDate: 'not-a-date',
+      subGoals: [{ title: '', description: '', estimatedHours: 1, suggestedTargetDate: null, tasks: [] }],
+      tasks: [
+        { title: '', description: '', estimatedCompletionTime: 2, suggestedTargetDate: null },
+        { title: 'Keep me', description: '', estimatedCompletionTime: 'abc', suggestedTargetDate: null }
+      ]
+    }
+  };
+  const client = makeClient(JSON.stringify(messyPlan));
+
+  const plan = await openaiService.generatePlan({ prompt: 'x', client });
+
+  expect(plan.goal.title).toBe('Messy goal');
+  expect(plan.goal.estimatedHours).toBe(0);
+  expect(plan.goal.suggestedTargetDate).toBeNull();
+  expect(plan.goal.subGoals).toHaveLength(0);
+  expect(plan.goal.tasks).toHaveLength(1);
+  expect(plan.goal.tasks[0].title).toBe('Keep me');
+  expect(plan.goal.tasks[0].estimatedCompletionTime).toBe(0);
+});
+
+test('generatePlan throws INVALID_AI_RESPONSE on unparseable content', async () => {
+  const client = makeClient('this is not json');
+  await expect(openaiService.generatePlan({ prompt: 'x', client })).rejects.toMatchObject({
+    code: 'INVALID_AI_RESPONSE'
+  });
+});
+
+test('generatePlan throws INVALID_AI_RESPONSE when the goal is missing', async () => {
+  const client = makeClient(JSON.stringify({ goal: { description: 'no title' } }));
+  await expect(openaiService.generatePlan({ prompt: 'x', client })).rejects.toMatchObject({
+    code: 'INVALID_AI_RESPONSE'
+  });
+});
+
+test('generatePlan throws EMPTY_AI_RESPONSE when no content is returned', async () => {
+  const client = { chat: { completions: { create: async () => ({ choices: [{ message: {} }] }) } } };
+  await expect(openaiService.generatePlan({ prompt: 'x', client })).rejects.toMatchObject({
+    code: 'EMPTY_AI_RESPONSE'
+  });
+});

--- a/app-server/app.js
+++ b/app-server/app.js
@@ -10,6 +10,7 @@ const authRoutes = require('./routes/authRoutes');
 const categoryRoutes = require('./routes/categoryRoutes');
 const googleCalendarRoutes = require('./routes/googleCalendarRoutes');
 const analyticsRoutes = require('./routes/analyticsRoutes');
+const aiRoutes = require('./routes/aiRoutes');
 
 const createApp = () => {
   // Initialize Express
@@ -54,6 +55,7 @@ const createApp = () => {
   app.use('/api/tasks', requireAuth, taskRoutes); // Routes for tasks
   app.use('/api/categories', requireAuth, categoryRoutes); // Routes for categories
   app.use('/api/analytics', requireAuth, analyticsRoutes);
+  app.use('/api/ai', requireAuth, aiRoutes);
   app.use('/api/integrations/google-calendar', googleCalendarRoutes);
 
   return app;

--- a/app-server/controllers/aiController.js
+++ b/app-server/controllers/aiController.js
@@ -1,0 +1,54 @@
+const Category = require('../models/category');
+const Goal = require('../models/goal');
+const openaiService = require('../services/openaiService');
+
+const errorStatusByCode = {
+  INVALID_PROMPT: 400,
+  OPENAI_NOT_CONFIGURED: 503,
+  EMPTY_AI_RESPONSE: 502,
+  INVALID_AI_RESPONSE: 502
+};
+
+const messageByCode = {
+  OPENAI_NOT_CONFIGURED: 'AI planning is not configured on the server.'
+};
+
+const generatePlan = async (req, res) => {
+  const { prompt } = req.body || {};
+
+  if (typeof prompt !== 'string' || !prompt.trim()) {
+    return res.status(400).json({ message: 'A prompt describing your goal is required' });
+  }
+
+  try {
+    const categories = await Category.find({ userId: req.user.id }, { title: 1 })
+      .sort({ title: 1 });
+    const existingGoals = await Goal.find(
+      { userId: req.user.id, parentGoalId: null },
+      { title: 1 }
+    ).limit(50);
+
+    const plan = await openaiService.generatePlan({
+      prompt: prompt.trim(),
+      categories: categories.map((category) => category.title),
+      existingGoalTitles: existingGoals.map((goal) => goal.title),
+      today: new Date().toISOString().slice(0, 10)
+    });
+
+    return res.status(200).json({ plan });
+  } catch (err) {
+    const status = errorStatusByCode[err.code];
+    if (status) {
+      return res.status(status).json({ message: messageByCode[err.code] || err.message });
+    }
+
+    console.error('AI plan generation failed', err);
+    return res.status(502).json({
+      message: 'Unable to generate a plan right now. Please try again.'
+    });
+  }
+};
+
+module.exports = {
+  generatePlan
+};

--- a/app-server/package-lock.json
+++ b/app-server/package-lock.json
@@ -14,7 +14,8 @@
         "express": "^4.21.2",
         "google-auth-library": "^9.15.0",
         "googleapis": "^150.0.1",
-        "mongoose": "^8.9.5"
+        "mongoose": "^8.9.5",
+        "openai": "^4.104.0"
       },
       "devDependencies": {
         "cross-env": "^10.0.0",
@@ -1257,10 +1258,19 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -1578,6 +1588,18 @@
         "win32"
       ]
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1598,6 +1620,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ansi-escapes": {
@@ -1691,7 +1725,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/b4a": {
@@ -2417,7 +2450,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -2592,7 +2624,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -2764,7 +2795,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2823,6 +2853,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/events-universal": {
@@ -3130,7 +3169,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -3141,6 +3179,34 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -3751,7 +3817,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3842,6 +3907,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -5534,6 +5608,51 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -6679,7 +6798,6 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/app-server/package.json
+++ b/app-server/package.json
@@ -22,7 +22,8 @@
     "express": "^4.21.2",
     "google-auth-library": "^9.15.0",
     "googleapis": "^150.0.1",
-    "mongoose": "^8.9.5"
+    "mongoose": "^8.9.5",
+    "openai": "^4.104.0"
   },
   "devDependencies": {
     "cross-env": "^10.0.0",

--- a/app-server/routes/aiRoutes.js
+++ b/app-server/routes/aiRoutes.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const { generatePlan } = require('../controllers/aiController');
+
+router.post('/plan', generatePlan);
+
+module.exports = router;

--- a/app-server/services/openaiService.js
+++ b/app-server/services/openaiService.js
@@ -1,0 +1,228 @@
+const OpenAI = require('openai');
+
+const DEFAULT_MODEL = process.env.OPENAI_MODEL || 'gpt-4o-mini';
+const REQUEST_TIMEOUT_MS = 30000;
+
+let cachedClient = null;
+
+const createServiceError = (message, code) => {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+};
+
+// The default client is created lazily so the server can boot (and tests can run)
+// without an API key; callers that don't inject a client must have OPENAI_API_KEY.
+const getDefaultClient = () => {
+  if (!process.env.OPENAI_API_KEY) {
+    throw createServiceError(
+      'OPENAI_API_KEY is not configured',
+      'OPENAI_NOT_CONFIGURED'
+    );
+  }
+
+  if (!cachedClient) {
+    cachedClient = new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+      timeout: REQUEST_TIMEOUT_MS,
+      maxRetries: 1
+    });
+  }
+
+  return cachedClient;
+};
+
+const taskSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    title: { type: 'string' },
+    description: { type: 'string' },
+    estimatedCompletionTime: { type: 'number' },
+    suggestedTargetDate: { type: ['string', 'null'] }
+  },
+  required: ['title', 'description', 'estimatedCompletionTime', 'suggestedTargetDate']
+};
+
+// Structured-output schema. Kept to one level of sub-goals (each with tasks) plus
+// top-level tasks so the model reliably returns something we can map onto the
+// Goal/Task Mongo models.
+const PLAN_JSON_SCHEMA = {
+  name: 'goal_plan',
+  strict: true,
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      goal: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          title: { type: 'string' },
+          description: { type: 'string' },
+          category: { type: 'string' },
+          estimatedHours: { type: 'number' },
+          suggestedTargetDate: { type: ['string', 'null'] },
+          subGoals: {
+            type: 'array',
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                title: { type: 'string' },
+                description: { type: 'string' },
+                estimatedHours: { type: 'number' },
+                suggestedTargetDate: { type: ['string', 'null'] },
+                tasks: { type: 'array', items: taskSchema }
+              },
+              required: ['title', 'description', 'estimatedHours', 'suggestedTargetDate', 'tasks']
+            }
+          },
+          tasks: { type: 'array', items: taskSchema }
+        },
+        required: ['title', 'description', 'category', 'estimatedHours', 'suggestedTargetDate', 'subGoals', 'tasks']
+      }
+    },
+    required: ['goal']
+  }
+};
+
+const buildSystemPrompt = ({ categories = [], today } = {}) => {
+  const categoryLine = categories.length
+    ? `The user already uses these categories: ${categories.join(', ')}. Prefer one of these for "category"; only invent a new short category name if none fit.`
+    : 'The user has no categories yet; choose a short, sensible category name for "category".';
+
+  return [
+    'You are a planning assistant embedded in a productivity app called Branchwork.',
+    'Given a user goal in natural language, produce a structured, actionable breakdown.',
+    'Break the goal into a small number of sub-goals (0-5), each with a few concrete tasks (0-6).',
+    'Also include any high-level tasks that belong directly under the top goal.',
+    'estimatedHours is the total effort in hours for a goal; estimatedCompletionTime is the effort in hours for a single task. Use realistic, non-negative numbers.',
+    `suggestedTargetDate must be an ISO date (YYYY-MM-DD) on or after ${today}, or null if no date makes sense.`,
+    categoryLine,
+    'Keep titles concise and descriptions to one or two sentences. Return only data that fits the provided JSON schema.'
+  ].join(' ');
+};
+
+const buildUserPrompt = ({ prompt, existingGoalTitles = [] } = {}) => {
+  const context = existingGoalTitles.length
+    ? `\n\nFor context, the user's existing top-level goals are: ${existingGoalTitles.join(', ')}. Do not duplicate these.`
+    : '';
+  return `Create a plan for the following goal:\n\n"${prompt}"${context}`;
+};
+
+const toSafeString = (value) => (typeof value === 'string' ? value.trim() : '');
+const toSafeNumber = (value) => {
+  const num = Number(value);
+  return Number.isFinite(num) && num > 0 ? Math.round(num * 100) / 100 : 0;
+};
+const toSafeDate = (value) => {
+  if (typeof value !== 'string' || !value.trim()) {
+    return null;
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : value.trim();
+};
+
+const normalizeTask = (task = {}) => ({
+  title: toSafeString(task.title),
+  description: toSafeString(task.description),
+  estimatedCompletionTime: toSafeNumber(task.estimatedCompletionTime),
+  suggestedTargetDate: toSafeDate(task.suggestedTargetDate)
+});
+
+const normalizeSubGoal = (subGoal = {}) => ({
+  title: toSafeString(subGoal.title),
+  description: toSafeString(subGoal.description),
+  estimatedHours: toSafeNumber(subGoal.estimatedHours),
+  suggestedTargetDate: toSafeDate(subGoal.suggestedTargetDate),
+  tasks: (Array.isArray(subGoal.tasks) ? subGoal.tasks : [])
+    .map(normalizeTask)
+    .filter((task) => task.title)
+});
+
+const normalizePlan = (parsed) => {
+  const goal = parsed && typeof parsed === 'object' ? parsed.goal : null;
+  if (!goal || typeof goal !== 'object' || !toSafeString(goal.title)) {
+    throw createServiceError(
+      'The AI returned an unreadable plan. Please try again.',
+      'INVALID_AI_RESPONSE'
+    );
+  }
+
+  return {
+    goal: {
+      title: toSafeString(goal.title),
+      description: toSafeString(goal.description),
+      category: toSafeString(goal.category),
+      estimatedHours: toSafeNumber(goal.estimatedHours),
+      suggestedTargetDate: toSafeDate(goal.suggestedTargetDate),
+      subGoals: (Array.isArray(goal.subGoals) ? goal.subGoals : [])
+        .map(normalizeSubGoal)
+        .filter((subGoal) => subGoal.title),
+      tasks: (Array.isArray(goal.tasks) ? goal.tasks : [])
+        .map(normalizeTask)
+        .filter((task) => task.title)
+    }
+  };
+};
+
+// Calls OpenAI (or an injected client, used by tests) and returns a validated,
+// normalized plan object ready for the client to preview and save.
+const generatePlan = async ({
+  prompt,
+  categories = [],
+  existingGoalTitles = [],
+  today = new Date().toISOString().slice(0, 10),
+  client
+} = {}) => {
+  const trimmedPrompt = toSafeString(prompt);
+  if (!trimmedPrompt) {
+    throw createServiceError(
+      'A prompt describing your goal is required',
+      'INVALID_PROMPT'
+    );
+  }
+
+  const openai = client || getDefaultClient();
+
+  const response = await openai.chat.completions.create({
+    model: DEFAULT_MODEL,
+    temperature: 0.4,
+    max_tokens: 1500,
+    response_format: { type: 'json_schema', json_schema: PLAN_JSON_SCHEMA },
+    messages: [
+      { role: 'system', content: buildSystemPrompt({ categories, today }) },
+      { role: 'user', content: buildUserPrompt({ prompt: trimmedPrompt, existingGoalTitles }) }
+    ]
+  });
+
+  const content = response?.choices?.[0]?.message?.content;
+  if (!content) {
+    throw createServiceError(
+      'The AI did not return a plan. Please try again.',
+      'EMPTY_AI_RESPONSE'
+    );
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(content);
+  } catch (err) {
+    throw createServiceError(
+      'The AI returned an unreadable plan. Please try again.',
+      'INVALID_AI_RESPONSE'
+    );
+  }
+
+  return normalizePlan(parsed);
+};
+
+module.exports = {
+  generatePlan,
+  buildSystemPrompt,
+  buildUserPrompt,
+  normalizePlan,
+  PLAN_JSON_SCHEMA,
+  DEFAULT_MODEL
+};

--- a/packages/shared/src/services.js
+++ b/packages/shared/src/services.js
@@ -60,6 +60,10 @@ const createServices = (client) => {
     return (await client.get(`/analytics/time-series${query ? `?${query}` : ''}`)).data;
   };
 
+  // AI planning
+  const generatePlan = async (prompt) =>
+    (await client.post('/ai/plan', { prompt })).data;
+
   // Google Calendar integration
   const fetchGoogleCalendarConnectUrl = async () =>
     (await client.get('/integrations/google-calendar/connect-url')).data;
@@ -95,6 +99,7 @@ const createServices = (client) => {
     fetchCategories,
     fetchTimeByCategory,
     fetchTimeSeries,
+    generatePlan,
     fetchGoogleCalendarConnectUrl,
     fetchGoogleCalendarStatus,
     fetchGoogleCalendars,

--- a/packages/shared/src/services.test.js
+++ b/packages/shared/src/services.test.js
@@ -74,6 +74,17 @@ test('analytics services append query strings', async () => {
   assert.ok(client.calls.some((c) => c.url === '/analytics/time-by-category'));
 });
 
+test('generatePlan posts the prompt to the ai route', async () => {
+  const client = makeClient();
+  const services = createServices(client);
+
+  await services.generatePlan('run a marathon');
+
+  const call = client.calls.find((c) => c.method === 'post' && c.url === '/ai/plan');
+  assert.ok(call);
+  assert.deepEqual(call.body, { prompt: 'run a marathon' });
+});
+
 test('google calendar services map to integration routes', async () => {
   const client = makeClient();
   const services = createServices(client);

--- a/src/components/AppShell.js
+++ b/src/components/AppShell.js
@@ -26,13 +26,16 @@ import ViewListOutlinedIcon from "@mui/icons-material/ViewListOutlined";
 import Brightness4OutlinedIcon from "@mui/icons-material/Brightness4Outlined";
 import Brightness7OutlinedIcon from "@mui/icons-material/Brightness7Outlined";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
 import { SITE_NAME } from "../config/branding";
 import { useAuth } from "../context/AuthContext";
+import AiPlannerDialog from "../features/ai/AiPlannerDialog";
 
 const drawerWidth = 280;
 
 const AppShell = ({ colorMode, onToggleColorMode }) => {
   const [open, setOpen] = useState(false);
+  const [aiPlannerOpen, setAiPlannerOpen] = useState(false);
   const [accountAnchorEl, setAccountAnchorEl] = useState(null);
   const location = useLocation();
   const navigate = useNavigate();
@@ -163,6 +166,16 @@ const AppShell = ({ colorMode, onToggleColorMode }) => {
                 "&::-webkit-scrollbar": { display: "none" }
               }}
             >
+              <Button
+                variant="contained"
+                color="secondary"
+                size="small"
+                startIcon={<AutoAwesomeOutlinedIcon />}
+                onClick={() => setAiPlannerOpen(true)}
+                sx={{ flexShrink: 0 }}
+              >
+                Plan with AI
+              </Button>
               {quickActions.map((action) => (
                 <Button
                   key={action.to}
@@ -321,6 +334,15 @@ const AppShell = ({ colorMode, onToggleColorMode }) => {
           </List>
         </Box>
       </Drawer>
+
+      <AiPlannerDialog
+        open={aiPlannerOpen}
+        onClose={() => setAiPlannerOpen(false)}
+        onSaved={() => {
+          setAiPlannerOpen(false);
+          navigate("/goals/overview");
+        }}
+      />
 
       <Box component="main" sx={{ pb: 4 }}>
         <Outlet />

--- a/src/features/ai/AiPlannerDialog.js
+++ b/src/features/ai/AiPlannerDialog.js
@@ -1,0 +1,354 @@
+import React, { useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControlLabel,
+  Paper,
+  Stack,
+  TextField,
+  Typography
+} from "@mui/material";
+import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
+import { generatePlan, savePlan } from "./aiService";
+
+const withId = (item, prefix, index) => ({ id: `${prefix}-${index}`, include: true, ...item });
+
+const toEditableForm = (plan) => {
+  const goal = plan?.goal || {};
+  return {
+    title: goal.title || "",
+    description: goal.description || "",
+    category: goal.category || "",
+    estimatedHours: goal.estimatedHours || 0,
+    suggestedTargetDate: goal.suggestedTargetDate || null,
+    tasks: (goal.tasks || []).map((task, index) => withId(task, "task", index)),
+    subGoals: (goal.subGoals || []).map((subGoal, index) => ({
+      ...withId(subGoal, "subgoal", index),
+      tasks: (subGoal.tasks || []).map((task, subIndex) =>
+        withId(task, `subgoal-${index}-task`, subIndex)
+      )
+    }))
+  };
+};
+
+const toPlanPayload = (form) => ({
+  goal: {
+    title: form.title.trim(),
+    description: form.description.trim(),
+    category: form.category.trim(),
+    estimatedHours: Number(form.estimatedHours) || 0,
+    suggestedTargetDate: form.suggestedTargetDate,
+    tasks: form.tasks
+      .filter((task) => task.include && task.title.trim())
+      .map((task) => ({
+        title: task.title.trim(),
+        description: task.description || "",
+        estimatedCompletionTime: Number(task.estimatedCompletionTime) || 0,
+        suggestedTargetDate: task.suggestedTargetDate
+      })),
+    subGoals: form.subGoals
+      .filter((subGoal) => subGoal.include && subGoal.title.trim())
+      .map((subGoal) => ({
+        title: subGoal.title.trim(),
+        description: subGoal.description || "",
+        estimatedHours: Number(subGoal.estimatedHours) || 0,
+        suggestedTargetDate: subGoal.suggestedTargetDate,
+        tasks: subGoal.tasks
+          .filter((task) => task.include && task.title.trim())
+          .map((task) => ({
+            title: task.title.trim(),
+            description: task.description || "",
+            estimatedCompletionTime: Number(task.estimatedCompletionTime) || 0,
+            suggestedTargetDate: task.suggestedTargetDate
+          }))
+      }))
+  }
+});
+
+const AiPlannerDialog = ({ open, onClose, onSaved }) => {
+  const [prompt, setPrompt] = useState("");
+  const [form, setForm] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  const resetAndClose = () => {
+    if (loading || saving) return;
+    setPrompt("");
+    setForm(null);
+    setError("");
+    onClose();
+  };
+
+  const handleGenerate = async () => {
+    if (!prompt.trim()) return;
+    setError("");
+    setLoading(true);
+    try {
+      const response = await generatePlan(prompt.trim());
+      setForm(toEditableForm(response.plan));
+    } catch (err) {
+      const message =
+        err?.response?.data?.message || "Unable to generate a plan right now. Please try again.";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setError("");
+    setSaving(true);
+    try {
+      await savePlan(toPlanPayload(form));
+      resetForms();
+      onSaved?.();
+    } catch (err) {
+      const message =
+        err?.response?.data?.message || "Unable to save this plan. Please try again.";
+      setError(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const resetForms = () => {
+    setPrompt("");
+    setForm(null);
+    setError("");
+  };
+
+  const updateGoalField = (field) => (event) =>
+    setForm((prev) => ({ ...prev, [field]: event.target.value }));
+
+  const updateTask = (taskId, field, value) =>
+    setForm((prev) => ({
+      ...prev,
+      tasks: prev.tasks.map((task) => (task.id === taskId ? { ...task, [field]: value } : task))
+    }));
+
+  const updateSubGoal = (subGoalId, field, value) =>
+    setForm((prev) => ({
+      ...prev,
+      subGoals: prev.subGoals.map((subGoal) =>
+        subGoal.id === subGoalId ? { ...subGoal, [field]: value } : subGoal
+      )
+    }));
+
+  const updateSubGoalTask = (subGoalId, taskId, field, value) =>
+    setForm((prev) => ({
+      ...prev,
+      subGoals: prev.subGoals.map((subGoal) =>
+        subGoal.id === subGoalId
+          ? {
+              ...subGoal,
+              tasks: subGoal.tasks.map((task) =>
+                task.id === taskId ? { ...task, [field]: value } : task
+              )
+            }
+          : subGoal
+      )
+    }));
+
+  const renderTaskRow = (task, onToggle, onTitleChange) => (
+    <Stack key={task.id} direction="row" spacing={1} sx={{ alignItems: "center" }}>
+      <Checkbox
+        size="small"
+        checked={task.include}
+        onChange={(event) => onToggle(event.target.checked)}
+      />
+      <TextField
+        size="small"
+        fullWidth
+        value={task.title}
+        onChange={(event) => onTitleChange(event.target.value)}
+        disabled={!task.include}
+      />
+      <Typography variant="caption" color="text.secondary" sx={{ whiteSpace: "nowrap" }}>
+        {Number(task.estimatedCompletionTime) || 0}h
+      </Typography>
+    </Stack>
+  );
+
+  return (
+    <Dialog open={open} onClose={resetAndClose} fullWidth maxWidth="md">
+      <DialogTitle sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <AutoAwesomeOutlinedIcon color="primary" />
+        Plan with AI
+      </DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2}>
+          {error && <Alert severity="error">{error}</Alert>}
+
+          <TextField
+            label="Describe your goal"
+            placeholder="e.g. I want to run a half marathon in 3 months"
+            value={prompt}
+            onChange={(event) => setPrompt(event.target.value)}
+            multiline
+            minRows={2}
+            fullWidth
+            disabled={loading || saving}
+          />
+
+          {!form && (
+            <Typography variant="body2" color="text.secondary">
+              The assistant will suggest a goal broken into sub-goals and tasks. Nothing is saved
+              until you review and confirm.
+            </Typography>
+          )}
+
+          {form && (
+            <>
+              <Divider>Proposed plan (review &amp; edit)</Divider>
+              <Paper variant="outlined" sx={{ p: 2, borderRadius: 2 }}>
+                <Stack spacing={2}>
+                  <TextField
+                    label="Goal"
+                    value={form.title}
+                    onChange={updateGoalField("title")}
+                    fullWidth
+                  />
+                  <TextField
+                    label="Description"
+                    value={form.description}
+                    onChange={updateGoalField("description")}
+                    fullWidth
+                    multiline
+                    minRows={2}
+                  />
+                  <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+                    <TextField
+                      label="Category"
+                      value={form.category}
+                      onChange={updateGoalField("category")}
+                      fullWidth
+                    />
+                    <TextField
+                      label="Estimated hours"
+                      type="number"
+                      value={form.estimatedHours}
+                      onChange={updateGoalField("estimatedHours")}
+                      sx={{ maxWidth: { sm: 180 } }}
+                    />
+                  </Stack>
+
+                  {form.tasks.length > 0 && (
+                    <Box>
+                      <Typography variant="subtitle2" fontWeight={700} gutterBottom>
+                        Tasks
+                      </Typography>
+                      <Stack spacing={1}>
+                        {form.tasks.map((task) =>
+                          renderTaskRow(
+                            task,
+                            (checked) => updateTask(task.id, "include", checked),
+                            (value) => updateTask(task.id, "title", value)
+                          )
+                        )}
+                      </Stack>
+                    </Box>
+                  )}
+
+                  {form.subGoals.map((subGoal) => (
+                    <Paper key={subGoal.id} variant="outlined" sx={{ p: 1.5, borderRadius: 2 }}>
+                      <Stack spacing={1}>
+                        <Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
+                          <FormControlLabel
+                            control={
+                              <Checkbox
+                                size="small"
+                                checked={subGoal.include}
+                                onChange={(event) =>
+                                  updateSubGoal(subGoal.id, "include", event.target.checked)
+                                }
+                              />
+                            }
+                            label=""
+                            sx={{ mr: 0 }}
+                          />
+                          <TextField
+                            size="small"
+                            fullWidth
+                            label="Sub-goal"
+                            value={subGoal.title}
+                            onChange={(event) =>
+                              updateSubGoal(subGoal.id, "title", event.target.value)
+                            }
+                            disabled={!subGoal.include}
+                          />
+                          <TextField
+                            size="small"
+                            type="number"
+                            label="Hrs"
+                            value={subGoal.estimatedHours}
+                            onChange={(event) =>
+                              updateSubGoal(subGoal.id, "estimatedHours", event.target.value)
+                            }
+                            disabled={!subGoal.include}
+                            sx={{ width: 90 }}
+                          />
+                        </Stack>
+                        {subGoal.tasks.length > 0 && (
+                          <Stack spacing={1} sx={{ pl: 4 }}>
+                            {subGoal.tasks.map((task) =>
+                              renderTaskRow(
+                                task,
+                                (checked) =>
+                                  updateSubGoalTask(subGoal.id, task.id, "include", checked),
+                                (value) => updateSubGoalTask(subGoal.id, task.id, "title", value)
+                              )
+                            )}
+                          </Stack>
+                        )}
+                      </Stack>
+                    </Paper>
+                  ))}
+                </Stack>
+              </Paper>
+            </>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, py: 2 }}>
+        <Button onClick={resetAndClose} disabled={loading || saving}>
+          Cancel
+        </Button>
+        {!form ? (
+          <Button
+            variant="contained"
+            onClick={handleGenerate}
+            disabled={loading || !prompt.trim()}
+            startIcon={loading ? <CircularProgress size={16} color="inherit" /> : <AutoAwesomeOutlinedIcon />}
+          >
+            {loading ? "Generating…" : "Generate plan"}
+          </Button>
+        ) : (
+          <>
+            <Button onClick={handleGenerate} disabled={loading || saving}>
+              Regenerate
+            </Button>
+            <Button
+              variant="contained"
+              onClick={handleSave}
+              disabled={saving || !form.title.trim()}
+              startIcon={saving ? <CircularProgress size={16} color="inherit" /> : null}
+            >
+              {saving ? "Saving…" : "Add to my goals"}
+            </Button>
+          </>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default AiPlannerDialog;

--- a/src/features/ai/aiService.js
+++ b/src/features/ai/aiService.js
@@ -1,0 +1,46 @@
+import services from '../../api/services';
+import { createGoal } from '../goals/goalService';
+import { createTask } from '../tasks/taskService';
+
+export const { generatePlan } = services;
+
+const buildGoalPayload = ({ title, description, estimatedHours, suggestedTargetDate, category, parentGoalId }) => {
+  const payload = { title, description, estimatedHours };
+  if (category) payload.category = category;
+  if (suggestedTargetDate) payload.targetCompletionDate = suggestedTargetDate;
+  if (parentGoalId) payload.parentGoalId = parentGoalId;
+  return payload;
+};
+
+const buildTaskPayload = ({ title, description, estimatedCompletionTime, suggestedTargetDate, parentGoalId }) => {
+  const payload = { title, description, estimatedCompletionTime, parentGoalId };
+  if (suggestedTargetDate) payload.targetCompletionDate = suggestedTargetDate;
+  return payload;
+};
+
+// Persists an (already reviewed) plan by reusing the standard goal/task
+// endpoints: the top goal first, then its direct tasks, then each sub-goal and
+// the sub-goal's tasks. Categories are inherited server-side for children.
+export const savePlan = async (plan) => {
+  const goal = plan?.goal;
+  if (!goal || !goal.title) {
+    throw new Error('There is no goal to save.');
+  }
+
+  const savedGoal = await createGoal(buildGoalPayload({ ...goal, category: goal.category }));
+
+  for (const task of goal.tasks || []) {
+    await createTask(buildTaskPayload({ ...task, parentGoalId: savedGoal._id }));
+  }
+
+  for (const subGoal of goal.subGoals || []) {
+    const savedSubGoal = await createGoal(
+      buildGoalPayload({ ...subGoal, parentGoalId: savedGoal._id })
+    );
+    for (const task of subGoal.tasks || []) {
+      await createTask(buildTaskPayload({ ...task, parentGoalId: savedSubGoal._id }));
+    }
+  }
+
+  return savedGoal;
+};

--- a/src/pages/GoalsOverview.js
+++ b/src/pages/GoalsOverview.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   Accordion,
@@ -23,7 +23,9 @@ import {
   Typography
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import AutoAwesomeOutlinedIcon from "@mui/icons-material/AutoAwesomeOutlined";
 import { fetchGoals } from "../features/goals/goalService";
+import AiPlannerDialog from "../features/ai/AiPlannerDialog";
 
 const sortOptions = [
   { value: "deadline", label: "Deadline" },
@@ -81,35 +83,25 @@ const GoalsOverview = () => {
   const [sortBy, setSortBy] = useState("deadline");
   const [thenBy, setThenBy] = useState("none");
   const [sortOrder, setSortOrder] = useState("asc");
+  const [aiPlannerOpen, setAiPlannerOpen] = useState(false);
+
+  const loadGoals = useCallback(async () => {
+    setError("");
+    setLoading(true);
+    try {
+      const goalData = await fetchGoals();
+      setGoals(goalData);
+    } catch (err) {
+      console.error(err);
+      setError("Unable to load goals right now.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
-    let isActive = true;
-
-    const loadGoals = async () => {
-      setError("");
-      setLoading(true);
-      try {
-        const goalData = await fetchGoals();
-        if (isActive) {
-          setGoals(goalData);
-        }
-      } catch (err) {
-        console.error(err);
-        if (isActive) {
-          setError("Unable to load goals right now.");
-        }
-      } finally {
-        if (isActive) {
-          setLoading(false);
-        }
-      }
-    };
-
     loadGoals();
-    return () => {
-      isActive = false;
-    };
-  }, []);
+  }, [loadGoals]);
 
   const dateFormatter = useMemo(
     () =>
@@ -407,14 +399,29 @@ const GoalsOverview = () => {
   return (
     <Container maxWidth="lg" sx={{ py: 4, textAlign: "left" }}>
       <Stack spacing={3}>
-        <Box>
-          <Typography variant="h4" fontWeight={700} gutterBottom>
-            In-depth goals view
-          </Typography>
-          <Typography variant="body1" color="text.secondary">
-            Review every top-level goal and dive deeper when you are ready.
-          </Typography>
-        </Box>
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          spacing={2}
+          sx={{ justifyContent: "space-between", alignItems: { sm: "flex-start" } }}
+        >
+          <Box>
+            <Typography variant="h4" fontWeight={700} gutterBottom>
+              In-depth goals view
+            </Typography>
+            <Typography variant="body1" color="text.secondary">
+              Review every top-level goal and dive deeper when you are ready.
+            </Typography>
+          </Box>
+          <Button
+            variant="contained"
+            color="secondary"
+            startIcon={<AutoAwesomeOutlinedIcon />}
+            onClick={() => setAiPlannerOpen(true)}
+            sx={{ alignSelf: { xs: "flex-start", sm: "center" }, flexShrink: 0 }}
+          >
+            Plan with AI
+          </Button>
+        </Stack>
 
         <Paper variant="outlined" sx={{ p: 2.5, borderRadius: 3 }}>
           <Stack spacing={2}>
@@ -578,6 +585,15 @@ const GoalsOverview = () => {
           <Stack spacing={2}>{sortedGoals.map((goal) => renderGoalCard(goal))}</Stack>
         )}
       </Stack>
+
+      <AiPlannerDialog
+        open={aiPlannerOpen}
+        onClose={() => setAiPlannerOpen(false)}
+        onSaved={() => {
+          setAiPlannerOpen(false);
+          loadGoals();
+        }}
+      />
     </Container>
   );
 };


### PR DESCRIPTION
## Summary
Adds a "Plan with AI" feature: a user describes a goal in plain English and OpenAI returns a structured breakdown (goal → sub-goals → tasks) that the user reviews/edits and then saves. Nothing is written to the DB until the user confirms — the AI only *proposes*, and persistence reuses the existing `createGoal`/`createTask` endpoints.

Key design point: **OpenAI is called only from the backend** (holds `OPENAI_API_KEY`); clients hit our own authenticated `POST /api/ai/plan`, mirroring how the Google Calendar integration wraps a third-party API. The AI's JSON is validated/sanitized server-side before it's returned.

### Backend
- `services/openaiService.js` — wraps the OpenAI SDK. Uses **Structured Outputs** (`response_format: json_schema`, strict) so the model returns JSON matching the Goal/Task shape. Lazily creates the client (server boots/tests run without a key), and a client can be injected for tests. Normalizes output: trims strings, clamps negative/NaN numbers to 0, drops invalid dates and empty items, and throws typed errors (`INVALID_PROMPT`, `EMPTY_AI_RESPONSE`, `INVALID_AI_RESPONSE`, `OPENAI_NOT_CONFIGURED`). Model defaults to `gpt-4o-mini` (`OPENAI_MODEL` override), `max_tokens` capped, 30s timeout.
- `controllers/aiController.js` + `routes/aiRoutes.js` — `POST /api/ai/plan` behind `requireAuth`. Loads the user's categories + top-level goal titles as prompt context and maps service error codes to HTTP status (400/502/503).
- `app.js` — mounts `app.use('/api/ai', requireAuth, aiRoutes)`.
- `.env.*.example` — documents `OPENAI_API_KEY` / `OPENAI_MODEL`.

```
client → POST /api/ai/plan (Google Bearer auth) → openaiService.generatePlan()
   → OpenAI (json_schema) → validate/normalize → { plan }
```

### Shared
- `packages/shared/src/services.js` — `generatePlan(prompt) → POST /ai/plan`, so web and mobile share it.

### Web
- `features/ai/aiService.js` — `savePlan(plan)` persists the reviewed plan via existing services: top goal → its tasks → each sub-goal (`parentGoalId`) → the sub-goal's tasks. Categories inherit server-side for children.
- `features/ai/AiPlannerDialog.js` — dialog: prompt box → loading → editable preview (edit titles/category/hours, per-item include checkboxes) → "Add to my goals" / "Regenerate".
- Entry points: primary **Plan with AI** button in the `AppShell` header (available everywhere) + a button on `GoalsOverview` (reloads goals on save).

## Testing
- Backend: `__tests__/openaiService.test.js` (injected fake client — prompt construction, normalization, all error paths) and `__tests__/aiRoutes.test.js` (auth, empty-prompt 400, success + context passing, 503/502). Shared: added a `generatePlan` mapping test.
- Full suites green: shared 81, backend 114, frontend 101; `CI=true` web build compiles.
- End-to-end verified locally against the **real OpenAI API** (backend on in-memory Mongo): entered a goal → reviewed the generated plan → saved → confirmed the goal, 4 sub-goals and all tasks persisted through the normal create endpoints.

### Screenshots
Reviewable proposed plan (editable, per-item checkboxes, nothing saved yet):

![AI planner proposed plan](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMzRmNmJkM2EzNTZmNGI5ODgxZGUxNzZlZjE0N2E3ODQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMzRmNmJkM2EzNTZmNGI5ODgxZGUxNzZlZjE0N2E3ODQvM2EyNmJhNzUtYmRjYS00NDU1LWE0NmMtNzU2MWIwNjFkMTZhIiwiaWF0IjoxNzg0MTg1NTM5LCJleHAiOjE3ODQ3OTAzMzksImZpbGVuYW1lIjoic3NfM2MwZDM3YTQucG5nIn0.-Q6EHnrJJE6H6R1k-IkoAK1GXlbnDyA-x26KqOj4FxI)

After "Add to my goals" — the plan saved as a real goal tree via existing APIs:

![Saved goal tree](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMzRmNmJkM2EzNTZmNGI5ODgxZGUxNzZlZjE0N2E3ODQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMzRmNmJkM2EzNTZmNGI5ODgxZGUxNzZlZjE0N2E3ODQvNTM4OTkyNGEtZDg3Ny00ZGViLTkwNWQtNTgyZTU4NmU5NjcwIiwiaWF0IjoxNzg0MTg1NTM5LCJleHAiOjE3ODQ3OTAzMzksImZpbGVuYW1lIjoic3NfZjFlNGJiODkucG5nIn0.aPjVJXlnj3HMIqo0IKEvknhhcNKXt1MsOpENVLDUn84)

## Follow-ups / notes
- Requires `OPENAI_API_KEY` in the backend env (and on Render for deploy).
- Mobile UI not added yet (shared service is ready). Conversational/tool-calling and an MCP server (to control the app from ChatGPT/Claude) are documented as future phases.


Link to Devin session: https://outpostai.devinenterprise.com/sessions/dd9a353dc9814328aa90a1f47c89c3a5
Requested by: @ysingh97